### PR TITLE
Db split

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ A module to store and interact with blocks.
 A module to store and interact with blocks
 
 - [`Blockchain`](#blockchain)
-    - [`new Blockchain(blockDB, detailsDB)`](#new-blockchainblockdb-detailsdb)
+    - [`new Blockchain(opts)`](#new-blockchainblockdb-detailsdb)
     - [`BlockChain` Properties](#blockchain-properties)
     - [`BlockChain` methods](#blockchain-methods)
-        - [`blockchain.init(cb)`](#blockchaininitcb)
         - [`blockchain.putBlock(block, [callback])`](#blockchainputblockblock-callback)
         - [`blockchain.getBlock(hash, [callback])`](#blockchaingetblockhash-callback)
         - [`blockchain.getBlockInfo(hash, cb)`](#blockchaingetblockinfohash-cb)
@@ -29,10 +28,11 @@ A module to store and interact with blocks
 ## `Blockchain`
 Implements functions for retrieving, manipulating and storing Ethereum's blockchain
 
-### `new Blockchain(blockDB, validate)`
+### `new Blockchain(opts)`
 Creates new Blockchain object 
-- `blockDB` - the database that backs the Blockchain. the `db` object is tested with [levelup](https://github.com/rvagg/node-levelup) but should with any store that implements [put](https://github.com/rvagg/node-levelup#dbputkey-value-options-callback), [get](https://github.com/rvagg/node-levelup#dbgetkey-options-callback) and [del](https://github.com/rvagg/node-levelup#dbdelkey-options-callback).
-- `validate` - this the flag to validate blocks (e.g. Proof-of-Work).
+- `opts.blockDB` - the database where Blocks are stored and retreived by hash. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
+- `opts.detailsDB` - the database where Block number resolutions and other metadata is stored. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
+- `opts.validate` - this the flag to validate blocks (e.g. Proof-of-Work).
 
 ### `BlockChain` Properties
 - `head` - The Head, the block that has the most weight
@@ -50,9 +50,9 @@ Adds a block to the blockchain.
 
 --------------------------------------------------------
 
-#### `blockchain.getBlock(hash, [callback])`
-Gets a block by it hash.
-- `hash`  - the block's hash
+#### `blockchain.getBlock(blockTag, [callback])`
+Gets a block by its blockTag.
+- `blockTag`  - the block's hash or number
 - `callback` - the callback. It is given two parameters `err` and the found `block` if any. 
 
 --------------------------------------------------------

--- a/index.js
+++ b/index.js
@@ -20,13 +20,15 @@ const rlp = ethUtil.rlp
 
 module.exports = Blockchain
 
-function Blockchain(db, validate) {
+function Blockchain(opts) {
+  opts = opts || {}
   const self = this
   // TODO: SET LOCK
   // defaults
-  self.db = db ? db : levelup('', { db: memdown })
-  self.validate = (validate === undefined ? true : validate)
-  self.ethash = self.validate ? new Ethash(db) : null
+  self.blockDb = opts.blockDb ? opts.blockDb : levelup('', { db: memdown })
+  self.detailsDb = opts.detailsDb ? opts.detailsDb : levelup('', { db: memdown })
+  self.validate = (opts.validate === undefined ? true : opts.validate)
+  self.ethash = self.validate ? new Ethash(self.detailsDb) : null
   self.meta = null
   self._initDone = false
   self._putSemaphore = semaphore(1)
@@ -45,7 +47,7 @@ function Blockchain(db, validate) {
 Blockchain.prototype._init = function (cb) {
   const self = this
 
-  self.db.get('meta', {
+  self.detailsDb.get('meta', {
     valueEncoding: 'json'
   }, onHeadFound)
 
@@ -160,7 +162,8 @@ Blockchain.prototype.putBlock = function (block, cb, isGenesis) {
 
 Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
   const self = this
-  var blockHash = block.hash().toString('hex')
+  var blockHash = block.hash()
+  var blockHashHexString = blockHash.toString('hex')
   var parentDetails
   var dbOps = []
 
@@ -173,7 +176,7 @@ Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
     verifyPOW,
     lookupParentBlock,
     rebuildInfo,
-    save,
+    (cb) => self._batchDbOps(dbOps, cb),
   ], cb)
 
   function verify (next) {
@@ -216,7 +219,7 @@ Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
     // add this block as a child to the parent's block details
     if (!isGenesis) {
       totalDifficulty.iadd(new BN(parentDetails.td))
-      parentDetails.staleChildren.push(blockHash)
+      parentDetails.staleChildren.push(blockHashHexString)
     }
 
     // store the block details
@@ -230,15 +233,20 @@ Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
     }
 
     dbOps.push({
+      db: 'details',
       type: 'put',
-      key: 'detail:' + blockHash.toString('hex'),
+      key: 'detail:' + blockHashHexString,
       valueEncoding: 'json',
       value: blockDetails,
     })
     // store the block
+    if (!Buffer.isBuffer(blockHash)) console.trace()
+
     dbOps.push({
+      db: 'block',
       type: 'put',
       key: blockHash,
+      keyEncoding: 'binary',
       valueEncoding: 'binary',
       value: block.serialize(),
     })
@@ -246,7 +254,7 @@ Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
     // need to update totalDifficulty
     if (block.isGenesis() || totalDifficulty.cmp(self.meta.td) === 1) {
       blockDetails.inChain = true
-      self.meta.rawHead = blockHash
+      self.meta.rawHead = blockHashHexString
       self.meta.height = ethUtil.bufferToInt(block.header.number)
       self.meta.td = totalDifficulty
 
@@ -255,14 +263,16 @@ Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
 
       // index by number
       dbOps.push({
+        db: 'details',
         type: 'put',
         key: blockNumber,
         valueEncoding: 'binary',
-        value: new Buffer(blockHash, 'hex'),
+        value: blockHash,
       })
 
       // save meta
       dbOps.push({
+        db: 'details',
         type: 'put',
         key: 'meta',
         valueEncoding: 'json',
@@ -270,13 +280,14 @@ Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
       })
 
       if (block.isGenesis()) {
-        self.meta.genesis = blockHash
+        self.meta.genesis = blockHashHexString
         next()
       } else {
-        self._rebuildBlockchain(blockHash, block.header.parentHash, parentDetails, dbOps, next)        
+        self._rebuildBlockchain(blockHashHexString, block.header.parentHash, parentDetails, dbOps, next)        
       }
     } else {
       dbOps.push({
+        db: 'details',
         type: 'put',
         key: 'detail:' + block.header.parentHash.toString('hex'),
         valueEncoding: 'json',
@@ -285,11 +296,6 @@ Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
       next()
     }
   }
-  
-  function save (next) {
-    self.db.batch(dbOps, next)
-  }
-
 }
 
 /**
@@ -298,34 +304,39 @@ Blockchain.prototype._putBlock = function (block, cb, isGenesis) {
  * @param {String|Buffer|Number} hash - the sha256 hash of the rlp encoding of the block
  * @param {Function} cb - the callback function
  */
-Blockchain.prototype.getBlock = function (hash, cb) {
+Blockchain.prototype.getBlock = function (blockTag, cb) {
   const self = this
-  var block
-
-  if (!Number.isInteger(hash)) {
-    hash = ethUtil.toBuffer(hash).toString('hex')
+  
+  // determine BlockTag type
+  if (Buffer.isBuffer(blockTag)) {
+    lookupByHash(blockTag, cb)
+    return
+  } else if (Number.isInteger(blockTag)) {
+    async.waterfall([
+      (cb) => lookupNumberToHash(blockTag, cb),
+      (blockHash, cb) => lookupByHash(blockHash, cb),
+    ], cb)
+    return
+  } else {
+    return cb(new Error('Unknown blockTag type'))
   }
 
-  self.db.get(hash, {
-    valueEncoding: 'binary'
-  }, function (err, value) {
-    if (err) {
-      return cb(err)
-    }
+  function lookupByHash(hash, cb){
+    self.blockDb.get(hash, {
+      keyEncoding: 'binary',
+      valueEncoding: 'binary'
+    }, (err, encodedBlock) => {
+      if (err) return cb(err)
+      let block = new Block(rlp.decode(encodedBlock))
+      cb(null, block)
+    })
+  }
 
-    // if blockhash
-    if (value.length === 32) {
-      self.db.get(hash, {
-        valueEncoding: 'binary'
-      }, function (err, blockHash) {
-        if (err) return cb(err)
-        self.getBlock(blockHash, cb)
-      })
-    } else {
-      block = new Block(rlp.decode(value))
-      cb(err, block)
-    }
-  })
+  function lookupNumberToHash(hexString, cb){
+    self.detailsDb.get(hexString, {
+      valueEncoding: 'binary'
+    }, cb)
+  }
 }
 
 /**
@@ -345,6 +356,7 @@ Blockchain.prototype.getBlocks = function (blockId, maxBlocks, skip, reverse, cb
     self.getBlock(blockId, function (err, block) {
       i++
 
+      // TODO: only abort happily if the error is a "block not found" error
       if (err) {
         return cb(null, blocks)
       }
@@ -376,7 +388,7 @@ Blockchain.prototype.getBlocks = function (blockId, maxBlocks, skip, reverse, cb
  */
 Blockchain.prototype.getDetails = function (hash, cb) {
   const self = this
-  self.db.get('detail:' + hash.toString('hex'), {
+  self.detailsDb.get('detail:' + hash.toString('hex'), {
     valueEncoding: 'json'
   }, cb)
 }
@@ -389,7 +401,7 @@ Blockchain.prototype.getDetails = function (hash, cb) {
  */
 Blockchain.prototype.putDetails = function (hash, val, cb) {
   const self = this
-  self.db.put('detail:' + hash.toString('hex'), val, {
+  self.detailsDb.put('detail:' + hash.toString('hex'), val, {
     valueEncoding: 'json'
   }, cb)
 }
@@ -408,29 +420,30 @@ Blockchain.prototype.selectNeededHashes = function (hashes, cb) {
   max = hashes.length - 1
   mid = min = 0
 
-  async.whilst(function () {
+  async.whilst(function test() {
     return max >= min
   },
-    function (cb2) {
-      self.getBlockInfo(hashes[mid], function (err, hash) {
-        if (!err && hash) {
-          min = mid + 1
-        } else {
-          max = mid - 1
-        }
+  function iterate(cb2) {
+    self.getBlockInfo(hashes[mid], function (err, hash) {
+      if (!err && hash) {
+        min = mid + 1
+      } else {
+        max = mid - 1
+      }
 
-        mid = Math.floor((min + max) / 2)
-        cb2()
-      })
-    },
-    function (err) {
-      cb(err, hashes.slice(min))
+      mid = Math.floor((min + max) / 2)
+      cb2()
     })
+  },
+  function onDone(err) {
+    if (err) return cb(err)
+    cb(null, hashes.slice(min))
+  })
 }
 
 Blockchain.prototype._saveMeta = function (cb) {
   const self = this
-  self.db.put('meta', self.meta, {
+  self.detailsDb.put('meta', self.meta, {
     keyEncoding: 'json'
   }, cb)
 }
@@ -454,13 +467,14 @@ Blockchain.prototype._rebuildBlockchain = function (hash, parentHash, parentDeta
   parentDetails.child = hash
 
   ops.push({
+    db: 'details',
     type: 'put',
     key: 'detail:' + parentHash.toString('hex'),
     valueEncoding: 'json',
     value: parentDetails
   })
 
-  // 结束
+  // exit early if parent is in chain
   if (parentDetails.inChain) {
     cb()
     return
@@ -478,7 +492,7 @@ Blockchain.prototype._rebuildBlockchain = function (hash, parentHash, parentDeta
   })
 
   function loadNumberIndex (done) {
-    self.db.get(parentDetails.number, {
+    self.detailsDb.get(parentDetails.number, {
       valueEncoding: 'binary'
     }, function (err, _staleHash) {
       if (err) return done(err)
@@ -500,12 +514,14 @@ Blockchain.prototype._rebuildBlockchain = function (hash, parentHash, parentDeta
 
       // reindex the block number
       ops.push({
+        db: 'details',
         type: 'put',
         valueEncoding: 'binary',
         key: staleDetails.number,
         value: new Buffer(parentHash, 'hex')
       })
       ops.push({
+        db: 'details',
         type: 'put',
         key: 'detail:' + staleHash.toString('hex'),
         value: staleDetails,
@@ -535,6 +551,12 @@ Blockchain.prototype.delBlock = function (blockhash, cb) {
     blockhash = blockhash.hash()
   }
 
+  async.series([
+    buildDBops,
+    getLastDeletesDetils,
+    (cb) => self._batchDbOps(dbOps, cb),
+  ], cb)
+
   function buildDBops (cb2) {
     self._delBlock(blockhash, dbOps, resetHeads, cb2)
   }
@@ -551,16 +573,6 @@ Blockchain.prototype.delBlock = function (blockhash, cb) {
       cb2(err)
     })
   }
-
-  function runDB (cb2) {
-    self.db.batch(dbOps, cb2)
-  }
-
-  async.series([
-    buildDBops,
-    getLastDeletesDetils,
-    runDB
-  ], cb)
 }
 
 Blockchain.prototype._delBlock = function (blockhash, dbOps, resetHeads, cb) {
@@ -568,12 +580,14 @@ Blockchain.prototype._delBlock = function (blockhash, dbOps, resetHeads, cb) {
   var details
 
   dbOps.push({
+    db: 'details',
     type: 'del',
     key: 'detail:' + blockhash.toString('hex')
   })
 
   // delete the block
   dbOps.push({
+    db: 'block',
     type: 'del',
     key: blockhash.toString('hex')
   })
@@ -689,17 +703,42 @@ Blockchain.prototype._iterator = function (name, func, cb) {
       details[name] = true
       // self.putDetails(blockhash, details, cb3)
       var dbops = [{
+        db: 'details',
+        type: 'put',
         key: 'detail:' + blockhash.toString('hex'),
         value: details,
         valueEncoding: 'json'
       }, {
+        db: 'details',
         type: 'put',
         key: 'meta',
         valueEncoding: 'json',
         value: self.meta
       }]
 
-      self.db.batch(dbops, cb3)
+      self._batchDbOps(dbOps, cb3)
     }
   }
+}
+
+Blockchain.prototype._batchDbOps = function(dbOps, cb){
+  const self = this
+  let blockDbOps = []
+  let detailsDbOps = []
+  dbOps.forEach((op) => {
+    switch(op.db) {
+      case 'block':
+        blockDbOps.push(op)
+        break
+      case 'details':
+        detailsDbOps.push(op)
+        break
+      default:
+        return cb(new Error('DB op did not specify known db:', op))
+    }
+  })
+  async.parallel([
+    (cb) => self.blockDb.batch(blockDbOps, cb),
+    (cb) => self.detailsDb.batch(detailsDbOps, cb),
+  ], cb)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockchain",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "description": "A module to store and interact with blocks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Turns the constructor arguments into an options obj.
Splits DB into `detailsDb` and `blockDb`

This is a breaking change.
