### PR TITLE
[Pre-Byzantium Release] v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.2] - 2017-09-19
+- Tightened dependencies to prevent the ``2.0.x`` version of the library to break
+  after ``ethereumjs`` Byzantium library updates
+
+[2.0.2]: https://github.com/ethereumjs/ethereumjs-blockchain/compare/v2.0.1...v2.0.2
+
 ## [2.0.1] - 2017-09-14
 - Fixed severe bug adding blocks before blockchain init is complete
+
+[2.0.1]: https://github.com/ethereumjs/ethereumjs-blockchain/compare/v2.0.0...v2.0.1
 
 ## [2.0.0] - 2017-01-01
 - Split ``db`` into ``blockDB`` and ``detailsDB`` (breaking)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockchain",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A module to store and interact with blocks",
   "main": "index.js",
   "scripts": {
@@ -25,9 +25,9 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-blockchain#readme",
   "dependencies": {
     "async": "^2.1.2",
-    "ethashjs": "^0.0.7",
-    "ethereumjs-block": "^1.2.2",
-    "ethereumjs-util": "^5.0.1",
+    "ethashjs": "~0.0.7",
+    "ethereumjs-block": "~1.6.0",
+    "ethereumjs-util": "~5.1.0",
     "flow-stoplight": "^1.0.0",
     "levelup": "^1.3.0",
     "memdown": "^1.1.0",


### PR DESCRIPTION
Tightened dependencies to prevent the ``2.0.x`` version of the library to break
 after ``ethereumjs`` Byzantium library updates