### PR TITLE
New release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [2.1.0] - 2017-10-11
+- ``Metro-Byzantium`` compatible
+- Updated ``ethereumjs-block`` dependency (new difficulty formula / difficulty bomb delay)
+
+[2.1.0]: https://github.com/ethereumjs/ethereumjs-blockchain/compare/v2.0.2...v2.1.0
+
 ## [2.0.2] - 2017-09-19
 - Tightened dependencies to prevent the ``2.0.x`` version of the library to break
   after ``ethereumjs`` Byzantium library updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockchain",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "A module to store and interact with blocks",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   "dependencies": {
     "async": "^2.1.2",
     "ethashjs": "~0.0.7",
-    "ethereumjs-block": "git+https://github.com/ethereumjs/ethereumjs-block.git#master",
+    "ethereumjs-block": "~1.7.0",
     "ethereumjs-util": "~5.1.0",
     "flow-stoplight": "^1.0.0",
     "levelup": "^1.3.0",


### PR DESCRIPTION
Versioned Byzantium release, will be published on npm after merge.

Depends on: https://github.com/ethereumjs/ethereumjs-block/pull/37

See: https://github.com/ethereumjs/ethereumjs-vm/issues/209