### PR TITLE
Added support for setting network, hardfork-specific validation, putHeader()/putHeaders() functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ new Blockchain({db: db}).iterator('i', (block, reorg, cb) => {
         - [`blockchain.putBlock(block, [cb])`](#blockchainputblockblock-cb)
         - [`blockchain.getBlock(hash, [cb])`](#blockchaingetblockhash-cb)
         - [`blockchain.getBlocks(blockId, maxBlocks, skip, reverse, [cb])`](#blockchaingetblocksblockid-maxblocks-skip-reverse-cb)
+        - [`blockchain.putHeaders(headers, [cb])`](#blockchainputheadersheaders-cb)
+        - [`blockchain.putHeader(header, [cb])`](#blockchainputheaderheader-cb)
         - [`blockchain.selectNeededHashes(hashes, [cb])`](#blockchainselectneededhasheshashes-cb)
         - [`blockchain.delBlock(blockHash, [cb])`](#blockchaindelblockblockhash-cb)
         - [`blockchain.iterator(name, onBlock, [cb])`](#blockchainiteratorname-onblock-cb)        
@@ -116,6 +118,19 @@ Looks up many blocks relative to blockId.
 - `skip` - number of blocks to skip
 - `reverse` - fetch blocks in reverse
 - `cb` - the callback. It is given two parameters `err` and the found `blocks` if any.
+
+--------------------------------------------------------
+
+#### `blockchain.putHeaders(headers, cb)`
+Adds many headers to the blockchain.
+- `headers` - the headers to be added to the blockchain
+- `cb` - the callback. It is given two parameters `err` and the last of the saved `headers`
+--------------------------------------------------------
+
+#### `blockchain.putHeader(header, cb)`
+Adds a header to the blockchain.
+- `header` - the header to be added to the blockchain
+- `cb` - the callback. It is given two parameters `err` and the saved `header`
 
 --------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "ethereumjs-util": "~5.2.0",
     "flow-stoplight": "^1.0.0",
     "levelup": "^1.3.0",
+    "lru-cache": "^4.1.2",
     "memdown": "^1.1.0",
     "safe-buffer": "^5.1.1",
-    "semaphore": "^1.0.3",
-    "lru-cache": "^4.1.2"
+    "semaphore": "^1.0.3"
   },
   "devDependencies": {
     "coveralls": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,21 +24,22 @@
   },
   "homepage": "https://github.com/ethereumjs/ethereumjs-blockchain#readme",
   "dependencies": {
-    "async": "^2.1.2",
+    "async": "^2.6.1",
     "ethashjs": "~0.0.7",
-    "ethereumjs-block": "~1.7.0",
+    "ethereumjs-block": "~2.0.1",
+    "ethereumjs-common": "~0.4.0",
     "ethereumjs-util": "~5.2.0",
     "flow-stoplight": "^1.0.0",
-    "levelup": "^1.3.0",
-    "lru-cache": "^4.1.2",
+    "levelup": "^1.3.2",
+    "lru-cache": "^4.1.3",
     "memdown": "^1.1.0",
-    "safe-buffer": "^5.1.1",
-    "semaphore": "^1.0.3"
+    "safe-buffer": "^5.1.2",
+    "semaphore": "^1.1.0"
   },
   "devDependencies": {
-    "coveralls": "^3.0.0",
-    "nyc": "^11.8.0",
+    "coveralls": "^3.0.2",
+    "nyc": "^13.0.1",
     "standard": "^11.0.1",
-    "tape": "^4.2.1"
+    "tape": "^4.9.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ const testData = require('./testdata.json')
 const BN = require('bn.js')
 
 test('blockchain test', function (t) {
-  t.plan(61)
+  t.plan(62)
   var blockchain = new Blockchain()
   var genesisBlock
   var blocks = []
@@ -373,6 +373,25 @@ test('blockchain test', function (t) {
           })
         ], done)
       })
+    },
+    function immutableCachedObjects (done) {
+      var blockchain = new Blockchain({validate: false})
+      var cachedHash
+      async.series([
+        (cb) => blockchain.putBlock(blocks[1], (err) => {
+          if (err) return done(err)
+          cachedHash = blocks[1].hash()
+          cb()
+        }),
+        (cb) => {
+          blocks[1].header.extraData = Buffer.from([1])
+          blockchain.getBlock(1, (err, block) => {
+            if (err) return done(err)
+            t.equals(cachedHash.toString('hex'), block.hash().toString('hex'), 'should not modify cached objects')
+            cb()
+          })
+        }
+      ], done)
     }
   ], function (err) {
     if (err) {


### PR DESCRIPTION
- Added support for setting network and performing hardfork-specific validation by integrating with ethereumjs-common
- Added putHeader() and putHeaders() functions to provide header-chain functionality needed by ethereumjs-client
- Fixed a bug with caching

Addresses #54.  These changes are needed by ``ethereumjs-client`` (and also for block 2.x support in ``ethereumjs-vm``)