### PR TITLE
Iterator should return without errors if no more blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -937,6 +937,10 @@ Blockchain.prototype._iterator = function (name, func, cb) {
         blockNumber.iaddn(1)
       } else {
         blockNumber = false
+        // No more blocks, return
+        if (err instanceof levelup.errors.NotFoundError) {
+          return cb2()
+        }
       }
       cb2(err)
     })

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ const BN = require('bn.js')
 const rlp = ethUtil.rlp
 
 test('blockchain test', function (t) {
-  t.plan(72)
+  t.plan(73)
   var blockchain = new Blockchain()
   var genesisBlock
   var blocks = []
@@ -253,7 +253,8 @@ test('blockchain test', function (t) {
       blockchain.iterator('test', function () {
         t.ok(false, 'should not call iterator function')
         done()
-      }, function () {
+      }, function (err) {
+        t.error(err, 'should not return error')
         t.ok(true, 'should finish iterating')
         done()
       })


### PR DESCRIPTION
[Propagating errors](https://github.com/ethereumjs/ethereumjs-blockchain/pull/60) in `iterator` has caused an issue that I unfortunately hadn't foreseen. I'm sorry about this.

It tries to get the next blocks, and when the next block doesn't exist, it returns the `NotFoundError` upstream, which shouldn't be the case. I tried to fix this with minimal change , however please let me know if you want it fixed in another way.

Furthermore the PR modifies the test case checking for iterating an empty blockchain to check for errors in callback.