### PR TITLE
Replace uses of deprecated `new Buffer` with Buffer.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,11 @@ const rlp = ethUtil.rlp
 // geth compatible db keys
 const headHeaderKey = 'LastHeader' // current canonical head for light sync
 const headBlockKey = 'LastBlock' // current canonical head for full sync
-const headerPrefix = new Buffer('h') // headerPrefix + number + hash -> header
-const tdSuffix = new Buffer('t') // headerPrefix + number + hash + tdSuffix -> td
-const numSuffix = new Buffer('n') // headerPrefix + number + numSuffix -> hash
-const blockHashPrefix = new Buffer('H') // blockHashPrefix + hash -> number
-const bodyPrefix = new Buffer('b') // bodyPrefix + number + hash -> block body
+const headerPrefix = Buffer.from('h') // headerPrefix + number + hash -> header
+const tdSuffix = Buffer.from('t') // headerPrefix + number + hash + tdSuffix -> td
+const numSuffix = Buffer.from('n') // headerPrefix + number + numSuffix -> hash
+const blockHashPrefix = Buffer.from('H') // blockHashPrefix + hash -> number
+const bodyPrefix = Buffer.from('b') // bodyPrefix + number + hash -> block body
 
 // utility functions
 const bufBE8 = n => n.toArrayLike(Buffer, 'be', 8) // convert BN to big endian Buffer


### PR DESCRIPTION
[`new Buffer(string [, encoding])`](https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding) is deprecated and this PR replaces the usages of it with [`Buffer.from(string [, encoding])`](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_string_encoding). It's been deprecated since Node v6, which is the earliest version we run CI using.