### PR TITLE
Fix levelup NotFoundError handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -939,7 +939,7 @@ Blockchain.prototype._iterator = function (name, func, cb) {
       } else {
         blockNumber = false
         // No more blocks, return
-        if (err instanceof level.errors.NotFoundError) {
+        if (err.type === 'NotFoundError') {
           return cb2()
         }
       }


### PR DESCRIPTION
VM tests are [failing](https://github.com/ethereumjs/ethereumjs-vm/pull/412) on the `iterate` method of `Blockchain`. I think the reason is different versions of `levelup` being used in the two projects. VM passes its `db` to Blockchain, which checks the error by `err instanceof level.errors.NotFoundError` on a more recent version of `levelup`.

The modified condition seems to work, but it's probably a good idea to update `levelup` in VM as well.