### PR TITLE
Move some db ops to DBManager

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@babel/env"],
+  "plugins": ["@babel/plugin-transform-runtime"]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
-  - "9"
+  - "10"
+  - "11"
 env:
   - CXX=g++-4.8
 addons:
@@ -18,9 +18,9 @@ matrix:
   fast_finish: true
   include:
     - os: linux
-      node_js: "6"
+      node_js: "8"
       env: CXX=g++-4.8 TEST_SUITE=coveralls
     - os: linux
-      node_js: "6"
+      node_js: "8"
       env: CXX=g++-4.8 TEST_SUITE=lint
 script: npm run $TEST_SUITE

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,0 @@
-const presets = [
-  [
-    '@babel/env'
-  ]
-]
-
-module.exports = { presets }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coverage": "nyc npm run test && nyc report --reporter=text-lcov > .nyc_output/lcov.info",
     "coveralls": "npm run coverage && coveralls <.nyc_output/lcov.info",
     "lint": "standard",
-    "test": "tape ./test/*.js"
+    "test": "babel-tape-runner ./test/*.js"
   },
   "repository": {
     "type": "git",
@@ -47,6 +47,7 @@
     "@babel/core": "^7.2.2",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.3.1",
+    "babel-tape-runner": "^3.0.0",
     "coveralls": "^3.0.2",
     "nyc": "^13.0.1",
     "standard": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "level-mem": "^3.0.1",
     "lru-cache": "^5.1.1",
     "safe-buffer": "^5.1.2",
-    "semaphore": "^1.1.0"
+    "semaphore": "^1.1.0",
+    "util": "^0.11.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/ethereumjs/ethereumjs-blockchain#readme",
   "dependencies": {
+    "@babel/runtime": "^7.3.1",
     "async": "^2.6.1",
     "ethashjs": "~0.0.7",
     "ethereumjs-block": "~2.2.0",
@@ -44,6 +45,7 @@
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
+    "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.3.1",
     "coveralls": "^3.0.2",
     "nyc": "^13.0.1",

--- a/src/dbManager.js
+++ b/src/dbManager.js
@@ -1,0 +1,194 @@
+const BN = require('bn.js')
+const level = require('level-mem')
+const rlp = require('rlp')
+const Block = require('ethereumjs-block')
+const Cache = require('./cache')
+const {
+  headsKey,
+  headHeaderKey,
+  headBlockKey,
+  hashToNumberKey,
+  numberToHashKey,
+  tdKey,
+  bodyKey,
+  headerKey
+} = require('./util')
+
+/**
+ * Abstraction over db to facilitate storing/fetching blockchain-related
+ * data, such as blocks and headers, indices, and the head block.
+ */
+module.exports = class DBManager {
+  constructor (db, common) {
+    this._db = db
+    this._common = common
+    this._cache = {
+      td: new Cache({ max: 1024 }),
+      header: new Cache({ max: 512 }),
+      body: new Cache({ max: 256 }),
+      numberToHash: new Cache({ max: 2048 }),
+      hashToNumber: new Cache({ max: 2048 })
+    }
+  }
+
+  /**
+   * Fetches iterator heads from the db.
+   * @returns Promise
+   */
+  getHeads () {
+    return this.get(headsKey, { valueEncoding: 'json' })
+  }
+
+  /**
+   * Fetches header of the head block.
+   * @returns Promise
+   */
+  getHeadHeader () {
+    return this.get(headHeaderKey)
+  }
+
+  /**
+   * Fetches head block.
+   * @returns Promise
+   */
+  getHeadBlock () {
+    return this.get(headBlockKey)
+  }
+
+  /**
+   * Fetches a block (header and body), given a block tag
+   * which can be either its hash or its number.
+   * @param {Buffer|BN|number} blockTag - Hash or number of the block
+   * @returns Promise
+   */
+  async getBlock (blockTag) {
+    // determine BlockTag type
+    if (Number.isInteger(blockTag)) {
+      blockTag = new BN(blockTag)
+    }
+
+    let number
+    let hash
+    if (Buffer.isBuffer(blockTag)) {
+      hash = blockTag
+      number = await this.hashToNumber(blockTag)
+    } else if (BN.isBN(blockTag)) {
+      number = blockTag
+      hash = await this.numberToHash(blockTag)
+    } else {
+      throw new Error('Unknown blockTag type')
+    }
+
+    const header = (await this.getHeader(hash, number)).raw
+    let body
+    try {
+      body = await this.getBody(hash, number)
+    } catch (e) {
+      body = [[], []]
+    }
+
+    return new Block([header].concat(body), {common: this._common})
+  }
+
+  /**
+   * Fetches body of a block given its hash and number.
+   * @param {Buffer} hash
+   * @param {BN} number
+   * @returns Promise
+   */
+  async getBody (hash, number) {
+    const key = bodyKey(number, hash)
+    return rlp.decode(await this.get(key, { cache: 'body' }))
+  }
+
+  /**
+   * Fetches header of a block given its hash and number.
+   * @param {Buffer} hash
+   * @param {BN} number
+   * @returns Promise
+   */
+  async getHeader (hash, number) {
+    const key = headerKey(number, hash)
+    let encodedHeader = await this.get(key, { cache: 'header' })
+    return new Block.Header(rlp.decode(encodedHeader), { common: this._common })
+  }
+
+  /**
+   * Fetches total difficulty for a block given its hash and number.
+   * @param {Buffer} hash
+   * @param {BN} number
+   * @returns Promise
+   */
+  async getTd (hash, number) {
+    const key = tdKey(number, hash)
+    const td = await this.get(key, { cache: 'td' })
+    return new BN(rlp.decode(td))
+  }
+
+  /**
+   * Performs a block hash to block number lookup.
+   * @param {Buffer} hash
+   * @returns Promise
+   */
+  async hashToNumber (hash) {
+    const key = hashToNumberKey(hash)
+    return new BN(await this.get(key, { cache: 'hashToNumber' }))
+  }
+
+  /**
+   * Performs a block number to block hash lookup.
+   * @param {BN} number
+   * @returns Promise
+   */
+  async numberToHash (number) {
+    if (number.ltn(0)) {
+      throw new level.errors.NotFoundError()
+    }
+
+    const key = numberToHashKey(number)
+    return this.get(key, { cache: 'numberToHash' })
+  }
+
+  /**
+   * Fetches a key from the db. If `opts.cache` is specified
+   * it first tries to load from cache, and on cache miss will
+   * try to put the fetched item on cache afterwards.
+   * @param {Buffer} key
+   * @param {Object} opts - Options and their default values are:
+   * - {string} [keyEncoding='binary']
+   * - {string} [valueEncodingr='binary']
+   * - {string} [cache=undefined] name of cache to use
+   * @returns Promise
+   */
+  async get (key, opts = {}) {
+    const dbOpts = {
+      keyEncoding: opts.keyEncoding || 'binary',
+      valueEncoding: opts.valueEncoding || 'binary'
+    }
+
+    if (opts.cache) {
+      if (!this._cache[opts.cache]) {
+        throw new Error(`Invalid cache: ${opts.cache}`)
+      }
+
+      let value = this._cache[opts.cache].get(key)
+      if (!value) {
+        value = await this._db.get(key, dbOpts)
+        this._cache[opts.cache].set(key, value)
+      }
+
+      return value
+    }
+
+    return this._db.get(key, dbOpts)
+  }
+
+  /**
+   * Performs a batch operation on db.
+   * @param {Array} ops
+   * @returns Promise
+   */
+  batch (ops) {
+    return this._db.batch(ops)
+  }
+}

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,29 @@
+// geth compatible db keys
+const headsKey = 'heads'
+const headHeaderKey = 'LastHeader' // current canonical head for light sync
+const headBlockKey = 'LastBlock' // current canonical head for full sync
+const headerPrefix = Buffer.from('h') // headerPrefix + number + hash -> header
+const tdSuffix = Buffer.from('t') // headerPrefix + number + hash + tdSuffix -> td
+const numSuffix = Buffer.from('n') // headerPrefix + number + numSuffix -> hash
+const blockHashPrefix = Buffer.from('H') // blockHashPrefix + hash -> number
+const bodyPrefix = Buffer.from('b') // bodyPrefix + number + hash -> block body
+
+// utility functions
+const bufBE8 = n => n.toArrayLike(Buffer, 'be', 8) // convert BN to big endian Buffer
+const tdKey = (n, hash) => Buffer.concat([headerPrefix, bufBE8(n), hash, tdSuffix])
+const headerKey = (n, hash) => Buffer.concat([headerPrefix, bufBE8(n), hash])
+const bodyKey = (n, hash) => Buffer.concat([bodyPrefix, bufBE8(n), hash])
+const numberToHashKey = n => Buffer.concat([headerPrefix, bufBE8(n), numSuffix])
+const hashToNumberKey = hash => Buffer.concat([blockHashPrefix, hash])
+
+module.exports = {
+  headsKey,
+  headHeaderKey,
+  headBlockKey,
+  bufBE8,
+  tdKey,
+  headerKey,
+  bodyKey,
+  numberToHashKey,
+  hashToNumberKey
+}


### PR DESCRIPTION
I started refactoring this by moving some of the (easier) db-related logic to a new class `DBManager` (which works with promises), and used `util.callbackify` in the same methods in `Blockchain`. I'm not sure if `util.callbackify` works in browser? (I think I remember browserify supports some libraries like `util`). But honestly, the bigger functions like `_putBlockOrHeader` are a piece of work, and I think rewriting it from scratch in typescript might be easier!