### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+
+[*.md]
+indent_size = 4


### PR DESCRIPTION
This PR adds a simple EditorConfig file.

From the site:

> EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The EditorConfig project consists of a **file format** for defining coding styles and a collection of **text editor plugins** that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.

It is important to note that this is a language- and tooling-agnostic configuration that simply allows for a cross-editor set of configurations to be shared. A large number of editors (including GitHub's built-in editor here) support these settings. See also: [the list of editors and plugins](https://editorconfig.org/#download).