### PR TITLE
Remove deprecated db options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,15 +1,13 @@
-
-#  ethereumjs-blockchain
+# ethereumjs-blockchain
 
 ## Index
 
 ### Classes
 
-* [Blockchain](classes/blockchain.md)
+- [Blockchain](classes/blockchain.md)
 
 ### Interfaces
 
-* [BlockchainOptions](interfaces/blockchainoptions.md)
+- [BlockchainOptions](interfaces/blockchainoptions.md)
 
 ---
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,15 @@
-# ethereumjs-blockchain
+
+#  ethereumjs-blockchain
 
 ## Index
 
 ### Classes
 
-- [Blockchain](classes/blockchain.md)
+* [Blockchain](classes/blockchain.md)
 
 ### Interfaces
 
-- [BlockchainOptions](interfaces/blockchainoptions.md)
+* [BlockchainOptions](interfaces/blockchainoptions.md)
 
 ---
+

--- a/docs/classes/blockchain.md
+++ b/docs/classes/blockchain.md
@@ -12,35 +12,35 @@ This class stores and interacts with blocks.
 
 ### Constructors
 
-- [constructor](blockchain.md#constructor)
+* [constructor](blockchain.md#constructor)
 
 ### Properties
 
-- [db](blockchain.md#db)
-- [dbManager](blockchain.md#dbmanager)
-- [ethash](blockchain.md#ethash)
-- [validate](blockchain.md#validate)
+* [db](blockchain.md#db)
+* [dbManager](blockchain.md#dbmanager)
+* [ethash](blockchain.md#ethash)
+* [validate](blockchain.md#validate)
 
 ### Accessors
 
-- [meta](blockchain.md#meta)
+* [meta](blockchain.md#meta)
 
 ### Methods
 
-- [delBlock](blockchain.md#delblock)
-- [getBlock](blockchain.md#getblock)
-- [getBlocks](blockchain.md#getblocks)
-- [getDetails](blockchain.md#getdetails)
-- [getHead](blockchain.md#gethead)
-- [getLatestBlock](blockchain.md#getlatestblock)
-- [getLatestHeader](blockchain.md#getlatestheader)
-- [iterator](blockchain.md#iterator)
-- [putBlock](blockchain.md#putblock)
-- [putBlocks](blockchain.md#putblocks)
-- [putGenesis](blockchain.md#putgenesis)
-- [putHeader](blockchain.md#putheader)
-- [putHeaders](blockchain.md#putheaders)
-- [selectNeededHashes](blockchain.md#selectneededhashes)
+* [delBlock](blockchain.md#delblock)
+* [getBlock](blockchain.md#getblock)
+* [getBlocks](blockchain.md#getblocks)
+* [getDetails](blockchain.md#getdetails)
+* [getHead](blockchain.md#gethead)
+* [getLatestBlock](blockchain.md#getlatestblock)
+* [getLatestHeader](blockchain.md#getlatestheader)
+* [iterator](blockchain.md#iterator)
+* [putBlock](blockchain.md#putblock)
+* [putBlocks](blockchain.md#putblocks)
+* [putGenesis](blockchain.md#putgenesis)
+* [putHeader](blockchain.md#putheader)
+* [putHeaders](blockchain.md#putheaders)
+* [selectNeededHashes](blockchain.md#selectneededhashes)
 
 ---
 
@@ -48,385 +48,366 @@ This class stores and interacts with blocks.
 
 <a id="constructor"></a>
 
-### constructor
+###  constructor
 
-⊕ **new Blockchain**(opts?: _[BlockchainOptions](../interfaces/blockchainoptions.md)_): [Blockchain](blockchain.md)
+⊕ **new Blockchain**(opts?: *[BlockchainOptions](../interfaces/blockchainoptions.md)*): [Blockchain](blockchain.md)
 
-_Defined in [index.ts:127](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L127)_
+*Defined in [index.ts:117](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L117)*
 
 Creates new Blockchain object
 
-**Deprecation note**:
-
-The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDb` from before the Geth DB-compatible `v3.0.0` release are deprecated and continued usage is discouraged. When provided `opts.blockDB` will be used as `opts.db` and `opts.detailsDB` is ignored. On the storage level the DB formats are not compatible and it is not possible to load an old-format DB state into a post-`v3.0.0` `Blockchain` object.
-
 **Parameters:**
 
-| Name                 | Type                                                    | Default value | Description                                                                                                          |
-| -------------------- | ------------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `Default value` opts | [BlockchainOptions](../interfaces/blockchainoptions.md) | {}            | An object with the options that this constructor takes. See [BlockchainOptions](../interfaces/blockchainoptions.md). |
+| Name | Type | Default value | Description |
+| ------ | ------ | ------ | ------ |
+| `Default value` opts | [BlockchainOptions](../interfaces/blockchainoptions.md) |  {} |  An object with the options that this constructor takes. See [BlockchainOptions](../interfaces/blockchainoptions.md). |
 
 **Returns:** [Blockchain](blockchain.md)
 
----
+___
 
 ## Properties
 
 <a id="db"></a>
 
-### db
+###  db
 
-**● db**: _`any`_
+**● db**: *`any`*
 
-_Defined in [index.ts:120](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L120)_
+*Defined in [index.ts:110](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L110)*
 
----
-
+___
 <a id="dbmanager"></a>
 
-### dbManager
+###  dbManager
 
-**● dbManager**: _`DBManager`_
+**● dbManager**: *`DBManager`*
 
-_Defined in [index.ts:121](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L121)_
+*Defined in [index.ts:111](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L111)*
 
----
-
+___
 <a id="ethash"></a>
 
-### ethash
+###  ethash
 
-**● ethash**: _`any`_
+**● ethash**: *`any`*
 
-_Defined in [index.ts:122](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L122)_
+*Defined in [index.ts:112](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L112)*
 
----
-
+___
 <a id="validate"></a>
 
-### validate
+###  validate
 
-**● validate**: _`boolean`_
+**● validate**: *`boolean`*
 
-_Defined in [index.ts:127](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L127)_
+*Defined in [index.ts:117](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L117)*
 
 A flag indicating if this Blockchain validates blocks or not.
 
----
+___
 
 ## Accessors
 
 <a id="meta"></a>
 
-### meta
+###  meta
 
 **get meta**(): `object`
 
-_Defined in [index.ts:182](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L182)_
+*Defined in [index.ts:164](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L164)*
 
 Returns an object with metadata about the Blockchain. It's defined for backwards compatibility.
 
 **Returns:** `object`
 
----
+___
 
 ## Methods
 
 <a id="delblock"></a>
 
-### delBlock
+###  delBlock
 
-▸ **delBlock**(blockHash: _`Buffer`_, cb: _`any`_): `void`
+▸ **delBlock**(blockHash: *`Buffer`*, cb: *`any`*): `void`
 
-_Defined in [index.ts:830](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L830)_
+*Defined in [index.ts:812](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L812)*
 
 Deletes a block from the blockchain. All child blocks in the chain are deleted and any encountered heads are set to the parent block.
 
 **Parameters:**
 
-| Name      | Type     | Description                         |
-| --------- | -------- | ----------------------------------- |
-| blockHash | `Buffer` | The hash of the block to be deleted |
-| cb        | `any`    | A callback.                         |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| blockHash | `Buffer` |  The hash of the block to be deleted |
+| cb | `any` |  A callback. |
 
 **Returns:** `void`
 
----
-
+___
 <a id="getblock"></a>
 
-### getBlock
+###  getBlock
 
-▸ **getBlock**(blockTag: _`Buffer` \| `number` \| `BN`_, cb: _`any`_): `void`
+▸ **getBlock**(blockTag: *`Buffer` \| `number` \| `BN`*, cb: *`any`*): `void`
 
-_Defined in [index.ts:567](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L567)_
+*Defined in [index.ts:549](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L549)*
 
 Gets a block by its hash.
 
 **Parameters:**
 
-| Name     | Type                         | Description                                                                                                                                                                                        |
-| -------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| blockTag | `Buffer` \| `number` \| `BN` | The block's hash or number                                                                                                                                                                         |
-| cb       | `any`                        | The callback. It is given two parameters \`err\` and the found \`block\` (an instance of [https://github.com/ethereumjs/ethereumjs-block](https://github.com/ethereumjs/ethereumjs-block)) if any. |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| blockTag | `Buffer` \| `number` \| `BN` |  The block's hash or number |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the found \`block\` (an instance of [https://github.com/ethereumjs/ethereumjs-block](https://github.com/ethereumjs/ethereumjs-block)) if any. |
 
 **Returns:** `void`
 
----
-
+___
 <a id="getblocks"></a>
 
-### getBlocks
+###  getBlocks
 
-▸ **getBlocks**(blockId: _`Buffer` \| `number`_, maxBlocks: _`number`_, skip: _`number`_, reverse: _`boolean`_, cb: _`any`_): `void`
+▸ **getBlocks**(blockId: *`Buffer` \| `number`*, maxBlocks: *`number`*, skip: *`number`*, reverse: *`boolean`*, cb: *`any`*): `void`
 
-_Defined in [index.ts:590](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L590)_
+*Defined in [index.ts:572](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L572)*
 
 Looks up many blocks relative to blockId
 
 **Parameters:**
 
-| Name      | Type                 | Description                                                                       |
-| --------- | -------------------- | --------------------------------------------------------------------------------- |
-| blockId   | `Buffer` \| `number` | The block's hash or number                                                        |
-| maxBlocks | `number`             | Max number of blocks to return                                                    |
-| skip      | `number`             | Number of blocks to skip                                                          |
-| reverse   | `boolean`            | Fetch blocks in reverse                                                           |
-| cb        | `any`                | The callback. It is given two parameters \`err\` and the found \`blocks\` if any. |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| blockId | `Buffer` \| `number` |  The block's hash or number |
+| maxBlocks | `number` |  Max number of blocks to return |
+| skip | `number` |  Number of blocks to skip |
+| reverse | `boolean` |  Fetch blocks in reverse |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the found \`blocks\` if any. |
 
 **Returns:** `void`
 
----
-
+___
 <a id="getdetails"></a>
 
-### getDetails
+###  getDetails
 
-▸ **getDetails**(\_: _`string`_, cb: _`any`_): `void`
+▸ **getDetails**(_: *`string`*, cb: *`any`*): `void`
 
-_Defined in [index.ts:631](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L631)_
+*Defined in [index.ts:613](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L613)*
 
 This method used to return block details by its hash. It's only here for backwards compatibility.
 
-_**deprecated**_:
+*__deprecated__*: 
 
 **Parameters:**
 
-| Name | Type     |
-| ---- | -------- |
-| \_   | `string` |
-| cb   | `any`    |
+| Name | Type |
+| ------ | ------ |
+| _ | `string` |
+| cb | `any` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="gethead"></a>
 
-### getHead
+###  getHead
 
-▸ **getHead**(name: _`any`_, cb?: _`any`_): `void`
+▸ **getHead**(name: *`any`*, cb?: *`any`*): `void`
 
-_Defined in [index.ts:278](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L278)_
+*Defined in [index.ts:260](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L260)*
 
 Returns the specified iterator head.
 
 **Parameters:**
 
-| Name          | Type  | Description                                                                 |
-| ------------- | ----- | --------------------------------------------------------------------------- |
-| name          | `any` | Optional name of the state root head (default: 'vm')                        |
-| `Optional` cb | `any` | The callback. It is given two parameters \`err\` and the returned \`block\` |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| name | `any` |  Optional name of the state root head (default: 'vm') |
+| `Optional` cb | `any` |  The callback. It is given two parameters \`err\` and the returned \`block\` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="getlatestblock"></a>
 
-### getLatestBlock
+###  getLatestBlock
 
-▸ **getLatestBlock**(cb: _`any`_): `void`
+▸ **getLatestBlock**(cb: *`any`*): `void`
 
-_Defined in [index.ts:318](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L318)_
+*Defined in [index.ts:300](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L300)*
 
 Returns the latest full block in the canonical chain.
 
 **Parameters:**
 
-| Name | Type  | Description                                                                 |
-| ---- | ----- | --------------------------------------------------------------------------- |
-| cb   | `any` | The callback. It is given two parameters \`err\` and the returned \`block\` |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the returned \`block\` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="getlatestheader"></a>
 
-### getLatestHeader
+###  getLatestHeader
 
-▸ **getLatestHeader**(cb: _`any`_): `void`
+▸ **getLatestHeader**(cb: *`any`*): `void`
 
-_Defined in [index.ts:301](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L301)_
+*Defined in [index.ts:283](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L283)*
 
 Returns the latest header in the canonical chain.
 
 **Parameters:**
 
-| Name | Type  | Description                                                                  |
-| ---- | ----- | ---------------------------------------------------------------------------- |
-| cb   | `any` | The callback. It is given two parameters \`err\` and the returned \`header\` |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the returned \`header\` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="iterator"></a>
 
-### iterator
+###  iterator
 
-▸ **iterator**(name: _`string`_, onBlock: _`any`_, cb: _`any`_): `void`
+▸ **iterator**(name: *`string`*, onBlock: *`any`*, cb: *`any`*): `void`
 
-_Defined in [index.ts:964](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L964)_
+*Defined in [index.ts:946](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L946)*
 
 Iterates through blocks starting at the specified iterator head and calls the onBlock function on each block. The current location of an iterator head can be retrieved using the `getHead()` method.
 
 **Parameters:**
 
-| Name    | Type     | Description                                                  |
-| ------- | -------- | ------------------------------------------------------------ |
-| name    | `string` | Name of the state root head                                  |
-| onBlock | `any`    | Function called on each block with params (block, reorg, cb) |
-| cb      | `any`    | A callback function                                          |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| name | `string` |  Name of the state root head |
+| onBlock | `any` |  Function called on each block with params (block, reorg, cb) |
+| cb | `any` |  A callback function |
 
 **Returns:** `void`
 
----
-
+___
 <a id="putblock"></a>
 
-### putBlock
+###  putBlock
 
-▸ **putBlock**(block: _`object`_, cb: _`any`_, isGenesis?: _`undefined` \| `false` \| `true`_): `void`
+▸ **putBlock**(block: *`object`*, cb: *`any`*, isGenesis?: *`undefined` \| `false` \| `true`*): `void`
 
-_Defined in [index.ts:347](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L347)_
+*Defined in [index.ts:329](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L329)*
 
 Adds a block to the blockchain.
 
 **Parameters:**
 
-| Name                 | Type                             | Description                                                              |
-| -------------------- | -------------------------------- | ------------------------------------------------------------------------ |
-| block                | `object`                         | The block to be added to the blockchain                                  |
-| cb                   | `any`                            | The callback. It is given two parameters \`err\` and the saved \`block\` |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| block | `object` |  The block to be added to the blockchain |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the saved \`block\` |
 | `Optional` isGenesis | `undefined` \| `false` \| `true` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="putblocks"></a>
 
-### putBlocks
+###  putBlocks
 
-▸ **putBlocks**(blocks: _`Array`<`any`>_, cb: _`any`_): `void`
+▸ **putBlocks**(blocks: *`Array`<`any`>*, cb: *`any`*): `void`
 
-_Defined in [index.ts:331](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L331)_
+*Defined in [index.ts:313](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L313)*
 
 Adds many blocks to the blockchain.
 
 **Parameters:**
 
-| Name   | Type           | Description                                                                           |
-| ------ | -------------- | ------------------------------------------------------------------------------------- |
-| blocks | `Array`<`any`> | The blocks to be added to the blockchain                                              |
-| cb     | `any`          | The callback. It is given two parameters \`err\` and the last of the saved \`blocks\` |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| blocks | `Array`<`any`> |  The blocks to be added to the blockchain |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the last of the saved \`blocks\` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="putgenesis"></a>
 
-### putGenesis
+###  putGenesis
 
-▸ **putGenesis**(genesis: _`any`_, cb: _`any`_): `void`
+▸ **putGenesis**(genesis: *`any`*, cb: *`any`*): `void`
 
-_Defined in [index.ts:268](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L268)_
+*Defined in [index.ts:250](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L250)*
 
 Puts the genesis block in the database
 
 **Parameters:**
 
-| Name    | Type  | Description                                                              |
-| ------- | ----- | ------------------------------------------------------------------------ |
-| genesis | `any` | The genesis block to be added                                            |
-| cb      | `any` | The callback. It is given two parameters \`err\` and the saved \`block\` |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| genesis | `any` |  The genesis block to be added |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the saved \`block\` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="putheader"></a>
 
-### putHeader
+###  putHeader
 
-▸ **putHeader**(header: _`object`_, cb: _`any`_): `void`
+▸ **putHeader**(header: *`object`*, cb: *`any`*): `void`
 
-_Defined in [index.ts:379](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L379)_
+*Defined in [index.ts:361](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L361)*
 
 Adds a header to the blockchain.
 
 **Parameters:**
 
-| Name   | Type     | Description                                                               |
-| ------ | -------- | ------------------------------------------------------------------------- |
-| header | `object` | The header to be added to the blockchain                                  |
-| cb     | `any`    | The callback. It is given two parameters \`err\` and the saved \`header\` |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| header | `object` |  The header to be added to the blockchain |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the saved \`header\` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="putheaders"></a>
 
-### putHeaders
+###  putHeaders
 
-▸ **putHeaders**(headers: _`Array`<`any`>_, cb: _`any`_): `void`
+▸ **putHeaders**(headers: *`Array`<`any`>*, cb: *`any`*): `void`
 
-_Defined in [index.ts:363](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L363)_
+*Defined in [index.ts:345](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L345)*
 
 Adds many headers to the blockchain.
 
 **Parameters:**
 
-| Name    | Type           | Description                                                                            |
-| ------- | -------------- | -------------------------------------------------------------------------------------- |
-| headers | `Array`<`any`> | The headers to be added to the blockchain                                              |
-| cb      | `any`          | The callback. It is given two parameters \`err\` and the last of the saved \`headers\` |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| headers | `Array`<`any`> |  The headers to be added to the blockchain |
+| cb | `any` |  The callback. It is given two parameters \`err\` and the last of the saved \`headers\` |
 
 **Returns:** `void`
 
----
-
+___
 <a id="selectneededhashes"></a>
 
-### selectNeededHashes
+###  selectNeededHashes
 
-▸ **selectNeededHashes**(hashes: _`Array`<`any`>_, cb: _`any`_): `void`
+▸ **selectNeededHashes**(hashes: *`Array`<`any`>*, cb: *`any`*): `void`
 
-_Defined in [index.ts:641](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L641)_
+*Defined in [index.ts:623](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L623)*
 
 Given an ordered array, returns to the callback an array of hashes that are not in the blockchain yet.
 
 **Parameters:**
 
-| Name   | Type           | Description                                                        |
-| ------ | -------------- | ------------------------------------------------------------------ |
-| hashes | `Array`<`any`> | Ordered array of hashes                                            |
-| cb     | `any`          | The callback. It is given two parameters \`err\` and hashes found. |
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| hashes | `Array`<`any`> |  Ordered array of hashes |
+| cb | `any` |  The callback. It is given two parameters \`err\` and hashes found. |
 
 **Returns:** `void`
 
----
+___
+

--- a/docs/classes/blockchain.md
+++ b/docs/classes/blockchain.md
@@ -12,35 +12,35 @@ This class stores and interacts with blocks.
 
 ### Constructors
 
-* [constructor](blockchain.md#constructor)
+- [constructor](blockchain.md#constructor)
 
 ### Properties
 
-* [db](blockchain.md#db)
-* [dbManager](blockchain.md#dbmanager)
-* [ethash](blockchain.md#ethash)
-* [validate](blockchain.md#validate)
+- [db](blockchain.md#db)
+- [dbManager](blockchain.md#dbmanager)
+- [ethash](blockchain.md#ethash)
+- [validate](blockchain.md#validate)
 
 ### Accessors
 
-* [meta](blockchain.md#meta)
+- [meta](blockchain.md#meta)
 
 ### Methods
 
-* [delBlock](blockchain.md#delblock)
-* [getBlock](blockchain.md#getblock)
-* [getBlocks](blockchain.md#getblocks)
-* [getDetails](blockchain.md#getdetails)
-* [getHead](blockchain.md#gethead)
-* [getLatestBlock](blockchain.md#getlatestblock)
-* [getLatestHeader](blockchain.md#getlatestheader)
-* [iterator](blockchain.md#iterator)
-* [putBlock](blockchain.md#putblock)
-* [putBlocks](blockchain.md#putblocks)
-* [putGenesis](blockchain.md#putgenesis)
-* [putHeader](blockchain.md#putheader)
-* [putHeaders](blockchain.md#putheaders)
-* [selectNeededHashes](blockchain.md#selectneededhashes)
+- [delBlock](blockchain.md#delblock)
+- [getBlock](blockchain.md#getblock)
+- [getBlocks](blockchain.md#getblocks)
+- [getDetails](blockchain.md#getdetails)
+- [getHead](blockchain.md#gethead)
+- [getLatestBlock](blockchain.md#getlatestblock)
+- [getLatestHeader](blockchain.md#getlatestheader)
+- [iterator](blockchain.md#iterator)
+- [putBlock](blockchain.md#putblock)
+- [putBlocks](blockchain.md#putblocks)
+- [putGenesis](blockchain.md#putgenesis)
+- [putHeader](blockchain.md#putheader)
+- [putHeaders](blockchain.md#putheaders)
+- [selectNeededHashes](blockchain.md#selectneededhashes)
 
 ---
 
@@ -48,366 +48,381 @@ This class stores and interacts with blocks.
 
 <a id="constructor"></a>
 
-###  constructor
+### constructor
 
-⊕ **new Blockchain**(opts?: *[BlockchainOptions](../interfaces/blockchainoptions.md)*): [Blockchain](blockchain.md)
+⊕ **new Blockchain**(opts?: _[BlockchainOptions](../interfaces/blockchainoptions.md)_): [Blockchain](blockchain.md)
 
-*Defined in [index.ts:117](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L117)*
+_Defined in [index.ts:117](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L117)_
 
 Creates new Blockchain object
 
 **Parameters:**
 
-| Name | Type | Default value | Description |
-| ------ | ------ | ------ | ------ |
-| `Default value` opts | [BlockchainOptions](../interfaces/blockchainoptions.md) |  {} |  An object with the options that this constructor takes. See [BlockchainOptions](../interfaces/blockchainoptions.md). |
+| Name                 | Type                                                    | Default value | Description                                                                                                          |
+| -------------------- | ------------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `Default value` opts | [BlockchainOptions](../interfaces/blockchainoptions.md) | {}            | An object with the options that this constructor takes. See [BlockchainOptions](../interfaces/blockchainoptions.md). |
 
 **Returns:** [Blockchain](blockchain.md)
 
-___
+---
 
 ## Properties
 
 <a id="db"></a>
 
-###  db
+### db
 
-**● db**: *`any`*
+**● db**: _`any`_
 
-*Defined in [index.ts:110](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L110)*
+_Defined in [index.ts:110](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L110)_
 
-___
+---
+
 <a id="dbmanager"></a>
 
-###  dbManager
+### dbManager
 
-**● dbManager**: *`DBManager`*
+**● dbManager**: _`DBManager`_
 
-*Defined in [index.ts:111](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L111)*
+_Defined in [index.ts:111](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L111)_
 
-___
+---
+
 <a id="ethash"></a>
 
-###  ethash
+### ethash
 
-**● ethash**: *`any`*
+**● ethash**: _`any`_
 
-*Defined in [index.ts:112](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L112)*
+_Defined in [index.ts:112](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L112)_
 
-___
+---
+
 <a id="validate"></a>
 
-###  validate
+### validate
 
-**● validate**: *`boolean`*
+**● validate**: _`boolean`_
 
-*Defined in [index.ts:117](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L117)*
+_Defined in [index.ts:117](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L117)_
 
 A flag indicating if this Blockchain validates blocks or not.
 
-___
+---
 
 ## Accessors
 
 <a id="meta"></a>
 
-###  meta
+### meta
 
 **get meta**(): `object`
 
-*Defined in [index.ts:164](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L164)*
+_Defined in [index.ts:164](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L164)_
 
 Returns an object with metadata about the Blockchain. It's defined for backwards compatibility.
 
 **Returns:** `object`
 
-___
+---
 
 ## Methods
 
 <a id="delblock"></a>
 
-###  delBlock
+### delBlock
 
-▸ **delBlock**(blockHash: *`Buffer`*, cb: *`any`*): `void`
+▸ **delBlock**(blockHash: _`Buffer`_, cb: _`any`_): `void`
 
-*Defined in [index.ts:812](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L812)*
+_Defined in [index.ts:812](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L812)_
 
 Deletes a block from the blockchain. All child blocks in the chain are deleted and any encountered heads are set to the parent block.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| blockHash | `Buffer` |  The hash of the block to be deleted |
-| cb | `any` |  A callback. |
+| Name      | Type     | Description                         |
+| --------- | -------- | ----------------------------------- |
+| blockHash | `Buffer` | The hash of the block to be deleted |
+| cb        | `any`    | A callback.                         |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="getblock"></a>
 
-###  getBlock
+### getBlock
 
-▸ **getBlock**(blockTag: *`Buffer` \| `number` \| `BN`*, cb: *`any`*): `void`
+▸ **getBlock**(blockTag: _`Buffer` \| `number` \| `BN`_, cb: _`any`_): `void`
 
-*Defined in [index.ts:549](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L549)*
+_Defined in [index.ts:549](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L549)_
 
 Gets a block by its hash.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| blockTag | `Buffer` \| `number` \| `BN` |  The block's hash or number |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the found \`block\` (an instance of [https://github.com/ethereumjs/ethereumjs-block](https://github.com/ethereumjs/ethereumjs-block)) if any. |
+| Name     | Type                         | Description                                                                                                                                                                                        |
+| -------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| blockTag | `Buffer` \| `number` \| `BN` | The block's hash or number                                                                                                                                                                         |
+| cb       | `any`                        | The callback. It is given two parameters \`err\` and the found \`block\` (an instance of [https://github.com/ethereumjs/ethereumjs-block](https://github.com/ethereumjs/ethereumjs-block)) if any. |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="getblocks"></a>
 
-###  getBlocks
+### getBlocks
 
-▸ **getBlocks**(blockId: *`Buffer` \| `number`*, maxBlocks: *`number`*, skip: *`number`*, reverse: *`boolean`*, cb: *`any`*): `void`
+▸ **getBlocks**(blockId: _`Buffer` \| `number`_, maxBlocks: _`number`_, skip: _`number`_, reverse: _`boolean`_, cb: _`any`_): `void`
 
-*Defined in [index.ts:572](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L572)*
+_Defined in [index.ts:572](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L572)_
 
 Looks up many blocks relative to blockId
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| blockId | `Buffer` \| `number` |  The block's hash or number |
-| maxBlocks | `number` |  Max number of blocks to return |
-| skip | `number` |  Number of blocks to skip |
-| reverse | `boolean` |  Fetch blocks in reverse |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the found \`blocks\` if any. |
+| Name      | Type                 | Description                                                                       |
+| --------- | -------------------- | --------------------------------------------------------------------------------- |
+| blockId   | `Buffer` \| `number` | The block's hash or number                                                        |
+| maxBlocks | `number`             | Max number of blocks to return                                                    |
+| skip      | `number`             | Number of blocks to skip                                                          |
+| reverse   | `boolean`            | Fetch blocks in reverse                                                           |
+| cb        | `any`                | The callback. It is given two parameters \`err\` and the found \`blocks\` if any. |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="getdetails"></a>
 
-###  getDetails
+### getDetails
 
-▸ **getDetails**(_: *`string`*, cb: *`any`*): `void`
+▸ **getDetails**(\_: _`string`_, cb: _`any`_): `void`
 
-*Defined in [index.ts:613](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L613)*
+_Defined in [index.ts:613](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L613)_
 
 This method used to return block details by its hash. It's only here for backwards compatibility.
 
-*__deprecated__*: 
+_**deprecated**_:
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _ | `string` |
-| cb | `any` |
+| Name | Type     |
+| ---- | -------- |
+| \_   | `string` |
+| cb   | `any`    |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="gethead"></a>
 
-###  getHead
+### getHead
 
-▸ **getHead**(name: *`any`*, cb?: *`any`*): `void`
+▸ **getHead**(name: _`any`_, cb?: _`any`_): `void`
 
-*Defined in [index.ts:260](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L260)*
+_Defined in [index.ts:260](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L260)_
 
 Returns the specified iterator head.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| name | `any` |  Optional name of the state root head (default: 'vm') |
-| `Optional` cb | `any` |  The callback. It is given two parameters \`err\` and the returned \`block\` |
+| Name          | Type  | Description                                                                 |
+| ------------- | ----- | --------------------------------------------------------------------------- |
+| name          | `any` | Optional name of the state root head (default: 'vm')                        |
+| `Optional` cb | `any` | The callback. It is given two parameters \`err\` and the returned \`block\` |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="getlatestblock"></a>
 
-###  getLatestBlock
+### getLatestBlock
 
-▸ **getLatestBlock**(cb: *`any`*): `void`
+▸ **getLatestBlock**(cb: _`any`_): `void`
 
-*Defined in [index.ts:300](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L300)*
+_Defined in [index.ts:300](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L300)_
 
 Returns the latest full block in the canonical chain.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the returned \`block\` |
+| Name | Type  | Description                                                                 |
+| ---- | ----- | --------------------------------------------------------------------------- |
+| cb   | `any` | The callback. It is given two parameters \`err\` and the returned \`block\` |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="getlatestheader"></a>
 
-###  getLatestHeader
+### getLatestHeader
 
-▸ **getLatestHeader**(cb: *`any`*): `void`
+▸ **getLatestHeader**(cb: _`any`_): `void`
 
-*Defined in [index.ts:283](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L283)*
+_Defined in [index.ts:283](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L283)_
 
 Returns the latest header in the canonical chain.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the returned \`header\` |
+| Name | Type  | Description                                                                  |
+| ---- | ----- | ---------------------------------------------------------------------------- |
+| cb   | `any` | The callback. It is given two parameters \`err\` and the returned \`header\` |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="iterator"></a>
 
-###  iterator
+### iterator
 
-▸ **iterator**(name: *`string`*, onBlock: *`any`*, cb: *`any`*): `void`
+▸ **iterator**(name: _`string`_, onBlock: _`any`_, cb: _`any`_): `void`
 
-*Defined in [index.ts:946](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L946)*
+_Defined in [index.ts:946](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L946)_
 
 Iterates through blocks starting at the specified iterator head and calls the onBlock function on each block. The current location of an iterator head can be retrieved using the `getHead()` method.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| name | `string` |  Name of the state root head |
-| onBlock | `any` |  Function called on each block with params (block, reorg, cb) |
-| cb | `any` |  A callback function |
+| Name    | Type     | Description                                                  |
+| ------- | -------- | ------------------------------------------------------------ |
+| name    | `string` | Name of the state root head                                  |
+| onBlock | `any`    | Function called on each block with params (block, reorg, cb) |
+| cb      | `any`    | A callback function                                          |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="putblock"></a>
 
-###  putBlock
+### putBlock
 
-▸ **putBlock**(block: *`object`*, cb: *`any`*, isGenesis?: *`undefined` \| `false` \| `true`*): `void`
+▸ **putBlock**(block: _`object`_, cb: _`any`_, isGenesis?: _`undefined` \| `false` \| `true`_): `void`
 
-*Defined in [index.ts:329](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L329)*
+_Defined in [index.ts:329](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L329)_
 
 Adds a block to the blockchain.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| block | `object` |  The block to be added to the blockchain |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the saved \`block\` |
+| Name                 | Type                             | Description                                                              |
+| -------------------- | -------------------------------- | ------------------------------------------------------------------------ |
+| block                | `object`                         | The block to be added to the blockchain                                  |
+| cb                   | `any`                            | The callback. It is given two parameters \`err\` and the saved \`block\` |
 | `Optional` isGenesis | `undefined` \| `false` \| `true` |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="putblocks"></a>
 
-###  putBlocks
+### putBlocks
 
-▸ **putBlocks**(blocks: *`Array`<`any`>*, cb: *`any`*): `void`
+▸ **putBlocks**(blocks: _`Array`<`any`>_, cb: _`any`_): `void`
 
-*Defined in [index.ts:313](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L313)*
+_Defined in [index.ts:313](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L313)_
 
 Adds many blocks to the blockchain.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| blocks | `Array`<`any`> |  The blocks to be added to the blockchain |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the last of the saved \`blocks\` |
+| Name   | Type           | Description                                                                           |
+| ------ | -------------- | ------------------------------------------------------------------------------------- |
+| blocks | `Array`<`any`> | The blocks to be added to the blockchain                                              |
+| cb     | `any`          | The callback. It is given two parameters \`err\` and the last of the saved \`blocks\` |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="putgenesis"></a>
 
-###  putGenesis
+### putGenesis
 
-▸ **putGenesis**(genesis: *`any`*, cb: *`any`*): `void`
+▸ **putGenesis**(genesis: _`any`_, cb: _`any`_): `void`
 
-*Defined in [index.ts:250](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L250)*
+_Defined in [index.ts:250](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L250)_
 
 Puts the genesis block in the database
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| genesis | `any` |  The genesis block to be added |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the saved \`block\` |
+| Name    | Type  | Description                                                              |
+| ------- | ----- | ------------------------------------------------------------------------ |
+| genesis | `any` | The genesis block to be added                                            |
+| cb      | `any` | The callback. It is given two parameters \`err\` and the saved \`block\` |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="putheader"></a>
 
-###  putHeader
+### putHeader
 
-▸ **putHeader**(header: *`object`*, cb: *`any`*): `void`
+▸ **putHeader**(header: _`object`_, cb: _`any`_): `void`
 
-*Defined in [index.ts:361](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L361)*
+_Defined in [index.ts:361](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L361)_
 
 Adds a header to the blockchain.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| header | `object` |  The header to be added to the blockchain |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the saved \`header\` |
+| Name   | Type     | Description                                                               |
+| ------ | -------- | ------------------------------------------------------------------------- |
+| header | `object` | The header to be added to the blockchain                                  |
+| cb     | `any`    | The callback. It is given two parameters \`err\` and the saved \`header\` |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="putheaders"></a>
 
-###  putHeaders
+### putHeaders
 
-▸ **putHeaders**(headers: *`Array`<`any`>*, cb: *`any`*): `void`
+▸ **putHeaders**(headers: _`Array`<`any`>_, cb: _`any`_): `void`
 
-*Defined in [index.ts:345](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L345)*
+_Defined in [index.ts:345](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L345)_
 
 Adds many headers to the blockchain.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| headers | `Array`<`any`> |  The headers to be added to the blockchain |
-| cb | `any` |  The callback. It is given two parameters \`err\` and the last of the saved \`headers\` |
+| Name    | Type           | Description                                                                            |
+| ------- | -------------- | -------------------------------------------------------------------------------------- |
+| headers | `Array`<`any`> | The headers to be added to the blockchain                                              |
+| cb      | `any`          | The callback. It is given two parameters \`err\` and the last of the saved \`headers\` |
 
 **Returns:** `void`
 
-___
+---
+
 <a id="selectneededhashes"></a>
 
-###  selectNeededHashes
+### selectNeededHashes
 
-▸ **selectNeededHashes**(hashes: *`Array`<`any`>*, cb: *`any`*): `void`
+▸ **selectNeededHashes**(hashes: _`Array`<`any`>_, cb: _`any`_): `void`
 
-*Defined in [index.ts:623](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L623)*
+_Defined in [index.ts:623](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L623)_
 
 Given an ordered array, returns to the callback an array of hashes that are not in the blockchain yet.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| hashes | `Array`<`any`> |  Ordered array of hashes |
-| cb | `any` |  The callback. It is given two parameters \`err\` and hashes found. |
+| Name   | Type           | Description                                                        |
+| ------ | -------------- | ------------------------------------------------------------------ |
+| hashes | `Array`<`any`> | Ordered array of hashes                                            |
+| cb     | `any`          | The callback. It is given two parameters \`err\` and hashes found. |
 
 **Returns:** `void`
 
-___
-
+---

--- a/docs/interfaces/blockchainoptions.md
+++ b/docs/interfaces/blockchainoptions.md
@@ -12,98 +12,69 @@ This are the options that the Blockchain constructor can receive.
 
 ### Properties
 
-- [blockDb](blockchainoptions.md#blockdb)
-- [chain](blockchainoptions.md#chain)
-- [common](blockchainoptions.md#common)
-- [db](blockchainoptions.md#db)
-- [detailsDb](blockchainoptions.md#detailsdb)
-- [hardfork](blockchainoptions.md#hardfork)
-- [validate](blockchainoptions.md#validate)
+* [chain](blockchainoptions.md#chain)
+* [common](blockchainoptions.md#common)
+* [db](blockchainoptions.md#db)
+* [hardfork](blockchainoptions.md#hardfork)
+* [validate](blockchainoptions.md#validate)
 
 ---
 
 ## Properties
 
-<a id="blockdb"></a>
-
-### `<Optional>` blockDb
-
-**● blockDb**: _`any`_
-
-_Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L58)_
-
-_**deprecated**_:
-
----
-
 <a id="chain"></a>
 
 ### `<Optional>` chain
 
-**● chain**: _`string` \| `number`_
+**● chain**: *`string` \| `number`*
 
-_Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L30)_
+*Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L30)*
 
 The chain id or name. Default: `"mainnet"`.
 
----
-
+___
 <a id="common"></a>
 
 ### `<Optional>` common
 
-**● common**: _`Common`_
+**● common**: *`Common`*
 
-_Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L41)_
+*Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L41)*
 
 An alternative way to specify the chain and hardfork is by passing a Common instance.
 
----
-
+___
 <a id="db"></a>
 
 ### `<Optional>` db
 
-**● db**: _`any`_
+**● db**: *`any`*
 
-_Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L47)_
+*Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L47)*
 
 Database to store blocks and metadata. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
 
----
-
-<a id="detailsdb"></a>
-
-### `<Optional>` detailsDb
-
-**● detailsDb**: _`any`_
-
-_Defined in [index.ts:63](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L63)_
-
-_**deprecated**_:
-
----
-
+___
 <a id="hardfork"></a>
 
 ### `<Optional>` hardfork
 
-**● hardfork**: _`string` \| `null`_
+**● hardfork**: *`string` \| `null`*
 
-_Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L36)_
+*Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L36)*
 
 Hardfork for the blocks. If `undefined` or `null` is passed, it gets computed based on block numbers.
 
----
-
+___
 <a id="validate"></a>
 
 ### `<Optional>` validate
 
-**● validate**: _`undefined` \| `false` \| `true`_
+**● validate**: *`undefined` \| `false` \| `true`*
 
-_Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L53)_
+*Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L53)*
 
 This the flag indicates if blocks should be validated (e.g. Proof-of-Work), latest HF rules supported: `Petersburg`.
 
----
+___
+

--- a/docs/interfaces/blockchainoptions.md
+++ b/docs/interfaces/blockchainoptions.md
@@ -12,11 +12,11 @@ This are the options that the Blockchain constructor can receive.
 
 ### Properties
 
-* [chain](blockchainoptions.md#chain)
-* [common](blockchainoptions.md#common)
-* [db](blockchainoptions.md#db)
-* [hardfork](blockchainoptions.md#hardfork)
-* [validate](blockchainoptions.md#validate)
+- [chain](blockchainoptions.md#chain)
+- [common](blockchainoptions.md#common)
+- [db](blockchainoptions.md#db)
+- [hardfork](blockchainoptions.md#hardfork)
+- [validate](blockchainoptions.md#validate)
 
 ---
 
@@ -26,55 +26,58 @@ This are the options that the Blockchain constructor can receive.
 
 ### `<Optional>` chain
 
-**● chain**: *`string` \| `number`*
+**● chain**: _`string` \| `number`_
 
-*Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L30)*
+_Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L30)_
 
 The chain id or name. Default: `"mainnet"`.
 
-___
+---
+
 <a id="common"></a>
 
 ### `<Optional>` common
 
-**● common**: *`Common`*
+**● common**: _`Common`_
 
-*Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L41)*
+_Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L41)_
 
 An alternative way to specify the chain and hardfork is by passing a Common instance.
 
-___
+---
+
 <a id="db"></a>
 
 ### `<Optional>` db
 
-**● db**: *`any`*
+**● db**: _`any`_
 
-*Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L47)*
+_Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L47)_
 
 Database to store blocks and metadata. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
 
-___
+---
+
 <a id="hardfork"></a>
 
 ### `<Optional>` hardfork
 
-**● hardfork**: *`string` \| `null`*
+**● hardfork**: _`string` \| `null`_
 
-*Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L36)*
+_Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L36)_
 
 Hardfork for the blocks. If `undefined` or `null` is passed, it gets computed based on block numbers.
 
-___
+---
+
 <a id="validate"></a>
 
 ### `<Optional>` validate
 
-**● validate**: *`undefined` \| `false` \| `true`*
+**● validate**: _`undefined` \| `false` \| `true`_
 
-*Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L53)*
+_Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/8190375/src/index.ts#L53)_
 
 This the flag indicates if blocks should be validated (e.g. Proof-of-Work), latest HF rules supported: `Petersburg`.
 
-___
-
+---

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,16 +51,6 @@ export interface BlockchainOptions {
    * supported: `Petersburg`.
    */
   validate?: boolean
-
-  /**
-   * @deprecated
-   */
-  blockDb?: any
-
-  /**
-   * @deprecated
-   */
-  detailsDb?: any
 }
 
 /**
@@ -129,13 +119,6 @@ export default class Blockchain {
   /**
    * Creates new Blockchain object
    *
-   * **Deprecation note**:
-   *
-   * The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDb` from before the Geth DB-compatible
-   * `v3.0.0` release are deprecated and continued usage is discouraged. When provided `opts.blockDB` will be used as
-   * `opts.db` and `opts.detailsDB` is ignored. On the storage level the DB formats are not compatible and it is not
-   * possible to load an old-format DB state into a post-`v3.0.0` `Blockchain` object.
-   *
    * @param opts - An object with the options that this constructor takes. See [[BlockchainOptions]].
    */
   constructor(opts: BlockchainOptions = {}) {
@@ -154,10 +137,9 @@ export default class Blockchain {
     if (opts.constructor.name === 'LevelUP') {
       opts = { db: opts }
     }
-    this.db = opts.db || opts.blockDb
 
     // defaults
-    this.db = this.db ? this.db : level()
+    this.db = opts.db ? opts.db : level()
     this.dbManager = new DBManager(this.db, this._common)
     this.validate = opts.validate === undefined ? true : opts.validate
     this.ethash = this.validate ? new Ethash(this.db) : null

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,11 +133,6 @@ export default class Blockchain {
       this._common = new Common(chain, hardfork)
     }
 
-    // backwards compatibility with older constructor interfaces
-    if (opts.constructor.name === 'LevelUP') {
-      opts = { db: opts }
-    }
-
     // defaults
     this.db = opts.db ? opts.db : level()
     this.dbManager = new DBManager(this.db, this._common)

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,7 +11,7 @@ const level = require('level-mem')
 const testData = require('./testdata.json')
 
 test('blockchain test', function(t) {
-  t.plan(71)
+  t.plan(70)
   const blockchain = new Blockchain()
   let genesisBlock: any
   const blocks: any[] = []
@@ -56,12 +56,6 @@ test('blockchain test', function(t) {
           )
           done()
         })
-      },
-      function alternateConstructors(done) {
-        const db = level()
-        let blockchain = new Blockchain(db)
-        t.equals(db, blockchain.db, 'support constructor with db parameter')
-        done()
       },
       function addgenesis(done) {
         genesisBlock = new Block()

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,7 +11,7 @@ const level = require('level-mem')
 const testData = require('./testdata.json')
 
 test('blockchain test', function(t) {
-  t.plan(73)
+  t.plan(71)
   const blockchain = new Blockchain()
   let genesisBlock: any
   const blocks: any[] = []
@@ -61,9 +61,6 @@ test('blockchain test', function(t) {
         const db = level()
         let blockchain = new Blockchain(db)
         t.equals(db, blockchain.db, 'support constructor with db parameter')
-        blockchain = new Blockchain({ detailsDb: db, blockDb: db })
-        t.equals(db, blockchain.db, 'support blockDb and detailsDb params')
-        t.notOk((<any>blockchain).detailsDb, 'ignore detailsDb param')
         done()
       },
       function addgenesis(done) {


### PR DESCRIPTION
I think we should use the occasion of a breaking release and get rid of the old DB constructor options. These have been deprecated by @vpulim along this major refactoring work https://github.com/ethereumjs/ethereumjs-blockchain/pull/47.

This PR removed both the ``opts.blockDb`` and ``opts.detailsDb`` options and the simplified no-opts-constructor directly passing in the DB (which adds very little benefit on the convenience level at the cost of higher complexity and eventually not very robust code).