### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,27 @@ A module to store and interact with blocks.
 # API
 
 [./docs/](./docs/README.md)
+
+# EXAMPLE USAGE
+
+The following is an example to iterate through an existing Geth DB (needs `level` to be installed separately).
+
+```javascript
+const level = require('level')
+const Blockchain = require('ethereumjs-blockchain')
+const utils = require('ethereumjs-util')
+
+const gethDbPath = './chaindata' // Add your own path here. It will get modified, see remarks.
+const db = level(gethDbPath)
+
+new Blockchain({ db: db }).iterator(
+  'i',
+  (block, reorg, cb) => {
+    const blockNumber = utils.bufferToInt(block.header.number)
+    const blockHash = block.hash().toString('hex')
+    console.log(`BLOCK ${blockNumber}: ${blockHash}`)
+    cb()
+  },
+  err => console.log(err || 'Done.'),
+)
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A module to store and interact with blocks.
 
 The following is an example to iterate through an existing Geth DB (needs `level` to be installed separately).
 
+This module performs write operations. Making a backup of your data before trying it is recommended. Otherwise, you can end up with a compromised DB state.
+
 ```javascript
 const level = require('level')
 const Blockchain = require('ethereumjs-blockchain')

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,8 @@
 
 - [Blockchain](classes/blockchain.md)
 
+### Interfaces
+
+- [BlockchainOptions](interfaces/blockchainoptions.md)
+
 ---

--- a/docs/classes/blockchain.md
+++ b/docs/classes/blockchain.md
@@ -4,8 +4,6 @@
 
 This class stores and interacts with blocks.
 
-_**remarks**_: This class performs write operations. Making a backup of your data before trying this module is recommended. Otherwise, you can end up with a compromised DB state.
-
 ## Hierarchy
 
 **Blockchain**
@@ -54,7 +52,7 @@ _**remarks**_: This class performs write operations. Making a backup of your dat
 
 ⊕ **new Blockchain**(opts?: _[BlockchainOptions](../interfaces/blockchainoptions.md)_): [Blockchain](blockchain.md)
 
-_Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L131)_
+_Defined in [index.ts:127](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L127)_
 
 Creates new Blockchain object
 
@@ -80,7 +78,7 @@ The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDb` 
 
 **● db**: _`any`_
 
-_Defined in [index.ts:124](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L124)_
+_Defined in [index.ts:120](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L120)_
 
 ---
 
@@ -90,7 +88,7 @@ _Defined in [index.ts:124](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● dbManager**: _`DBManager`_
 
-_Defined in [index.ts:125](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L125)_
+_Defined in [index.ts:121](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L121)_
 
 ---
 
@@ -100,7 +98,7 @@ _Defined in [index.ts:125](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● ethash**: _`any`_
 
-_Defined in [index.ts:126](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L126)_
+_Defined in [index.ts:122](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L122)_
 
 ---
 
@@ -110,7 +108,7 @@ _Defined in [index.ts:126](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● validate**: _`boolean`_
 
-_Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L131)_
+_Defined in [index.ts:127](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L127)_
 
 A flag indicating if this Blockchain validates blocks or not.
 
@@ -124,7 +122,7 @@ A flag indicating if this Blockchain validates blocks or not.
 
 **get meta**(): `object`
 
-_Defined in [index.ts:186](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L186)_
+_Defined in [index.ts:182](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L182)_
 
 Returns an object with metadata about the Blockchain. It's defined for backwards compatibility.
 
@@ -140,7 +138,7 @@ Returns an object with metadata about the Blockchain. It's defined for backwards
 
 ▸ **delBlock**(blockHash: _`Buffer`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:834](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L834)_
+_Defined in [index.ts:830](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L830)_
 
 Deletes a block from the blockchain. All child blocks in the chain are deleted and any encountered heads are set to the parent block.
 
@@ -161,7 +159,7 @@ Deletes a block from the blockchain. All child blocks in the chain are deleted a
 
 ▸ **getBlock**(blockTag: _`Buffer` \| `number` \| `BN`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:571](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L571)_
+_Defined in [index.ts:567](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L567)_
 
 Gets a block by its hash.
 
@@ -182,7 +180,7 @@ Gets a block by its hash.
 
 ▸ **getBlocks**(blockId: _`Buffer` \| `number`_, maxBlocks: _`number`_, skip: _`number`_, reverse: _`boolean`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:594](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L594)_
+_Defined in [index.ts:590](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L590)_
 
 Looks up many blocks relative to blockId
 
@@ -206,7 +204,7 @@ Looks up many blocks relative to blockId
 
 ▸ **getDetails**(\_: _`string`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:635](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L635)_
+_Defined in [index.ts:631](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L631)_
 
 This method used to return block details by its hash. It's only here for backwards compatibility.
 
@@ -229,7 +227,7 @@ _**deprecated**_:
 
 ▸ **getHead**(name: _`any`_, cb?: _`any`_): `void`
 
-_Defined in [index.ts:282](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L282)_
+_Defined in [index.ts:278](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L278)_
 
 Returns the specified iterator head.
 
@@ -250,7 +248,7 @@ Returns the specified iterator head.
 
 ▸ **getLatestBlock**(cb: _`any`_): `void`
 
-_Defined in [index.ts:322](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L322)_
+_Defined in [index.ts:318](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L318)_
 
 Returns the latest full block in the canonical chain.
 
@@ -270,7 +268,7 @@ Returns the latest full block in the canonical chain.
 
 ▸ **getLatestHeader**(cb: _`any`_): `void`
 
-_Defined in [index.ts:305](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L305)_
+_Defined in [index.ts:301](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L301)_
 
 Returns the latest header in the canonical chain.
 
@@ -290,7 +288,7 @@ Returns the latest header in the canonical chain.
 
 ▸ **iterator**(name: _`string`_, onBlock: _`any`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:968](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L968)_
+_Defined in [index.ts:964](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L964)_
 
 Iterates through blocks starting at the specified iterator head and calls the onBlock function on each block. The current location of an iterator head can be retrieved using the `getHead()` method.
 
@@ -312,7 +310,7 @@ Iterates through blocks starting at the specified iterator head and calls the on
 
 ▸ **putBlock**(block: _`object`_, cb: _`any`_, isGenesis?: _`undefined` \| `false` \| `true`_): `void`
 
-_Defined in [index.ts:351](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L351)_
+_Defined in [index.ts:347](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L347)_
 
 Adds a block to the blockchain.
 
@@ -334,7 +332,7 @@ Adds a block to the blockchain.
 
 ▸ **putBlocks**(blocks: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:335](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L335)_
+_Defined in [index.ts:331](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L331)_
 
 Adds many blocks to the blockchain.
 
@@ -355,7 +353,7 @@ Adds many blocks to the blockchain.
 
 ▸ **putGenesis**(genesis: _`any`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:272](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L272)_
+_Defined in [index.ts:268](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L268)_
 
 Puts the genesis block in the database
 
@@ -376,7 +374,7 @@ Puts the genesis block in the database
 
 ▸ **putHeader**(header: _`object`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:383](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L383)_
+_Defined in [index.ts:379](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L379)_
 
 Adds a header to the blockchain.
 
@@ -397,7 +395,7 @@ Adds a header to the blockchain.
 
 ▸ **putHeaders**(headers: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:367](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L367)_
+_Defined in [index.ts:363](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L363)_
 
 Adds many headers to the blockchain.
 
@@ -418,7 +416,7 @@ Adds many headers to the blockchain.
 
 ▸ **selectNeededHashes**(hashes: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:645](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L645)_
+_Defined in [index.ts:641](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L641)_
 
 Given an ordered array, returns to the callback an array of hashes that are not in the blockchain yet.
 

--- a/docs/classes/blockchain.md
+++ b/docs/classes/blockchain.md
@@ -6,28 +6,6 @@ This class stores and interacts with blocks.
 
 _**remarks**_: This class performs write operations. Making a backup of your data before trying this module is recommended. Otherwise, you can end up with a compromised DB state.
 
-_**example**_: The following is an example to iterate through an existing Geth DB (needs `level` to be installed separately).
-
-```javascript
-const level = require('level')
-const Blockchain = require('ethereumjs-blockchain')
-const utils = require('ethereumjs-util')
-
-const gethDbPath = './chaindata' // Add your own path here. It will get modified, see remarks.
-const db = level(gethDbPath)
-
-new Blockchain({ db: db }).iterator(
-  'i',
-  (block, reorg, cb) => {
-    const blockNumber = utils.bufferToInt(block.header.number)
-    const blockHash = block.hash().toString('hex')
-    console.log(`BLOCK ${blockNumber}: ${blockHash}`)
-    cb()
-  },
-  err => console.log(err \|\| 'Done.'),
-)
-```
-
 ## Hierarchy
 
 **Blockchain**
@@ -76,7 +54,7 @@ new Blockchain({ db: db }).iterator(
 
 ⊕ **new Blockchain**(opts?: _[BlockchainOptions](../interfaces/blockchainoptions.md)_): [Blockchain](blockchain.md)
 
-_Defined in [index.ts:155](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L155)_
+_Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L131)_
 
 Creates new Blockchain object
 
@@ -102,7 +80,7 @@ The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDb` 
 
 **● db**: _`any`_
 
-_Defined in [index.ts:148](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L148)_
+_Defined in [index.ts:124](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L124)_
 
 ---
 
@@ -112,7 +90,7 @@ _Defined in [index.ts:148](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● dbManager**: _`DBManager`_
 
-_Defined in [index.ts:149](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L149)_
+_Defined in [index.ts:125](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L125)_
 
 ---
 
@@ -122,7 +100,7 @@ _Defined in [index.ts:149](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● ethash**: _`any`_
 
-_Defined in [index.ts:150](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L150)_
+_Defined in [index.ts:126](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L126)_
 
 ---
 
@@ -132,7 +110,7 @@ _Defined in [index.ts:150](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● validate**: _`boolean`_
 
-_Defined in [index.ts:155](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L155)_
+_Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L131)_
 
 A flag indicating if this Blockchain validates blocks or not.
 
@@ -146,7 +124,7 @@ A flag indicating if this Blockchain validates blocks or not.
 
 **get meta**(): `object`
 
-_Defined in [index.ts:210](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L210)_
+_Defined in [index.ts:186](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L186)_
 
 Returns an object with metadata about the Blockchain. It's defined for backwards compatibility.
 
@@ -162,7 +140,7 @@ Returns an object with metadata about the Blockchain. It's defined for backwards
 
 ▸ **delBlock**(blockHash: _`Buffer`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:858](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L858)_
+_Defined in [index.ts:834](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L834)_
 
 Deletes a block from the blockchain. All child blocks in the chain are deleted and any encountered heads are set to the parent block.
 
@@ -183,7 +161,7 @@ Deletes a block from the blockchain. All child blocks in the chain are deleted a
 
 ▸ **getBlock**(blockTag: _`Buffer` \| `number` \| `BN`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:595](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L595)_
+_Defined in [index.ts:571](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L571)_
 
 Gets a block by its hash.
 
@@ -204,7 +182,7 @@ Gets a block by its hash.
 
 ▸ **getBlocks**(blockId: _`Buffer` \| `number`_, maxBlocks: _`number`_, skip: _`number`_, reverse: _`boolean`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:618](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L618)_
+_Defined in [index.ts:594](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L594)_
 
 Looks up many blocks relative to blockId
 
@@ -228,7 +206,7 @@ Looks up many blocks relative to blockId
 
 ▸ **getDetails**(\_: _`string`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:659](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L659)_
+_Defined in [index.ts:635](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L635)_
 
 This method used to return block details by its hash. It's only here for backwards compatibility.
 
@@ -251,7 +229,7 @@ _**deprecated**_:
 
 ▸ **getHead**(name: _`any`_, cb?: _`any`_): `void`
 
-_Defined in [index.ts:306](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L306)_
+_Defined in [index.ts:282](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L282)_
 
 Returns the specified iterator head.
 
@@ -272,7 +250,7 @@ Returns the specified iterator head.
 
 ▸ **getLatestBlock**(cb: _`any`_): `void`
 
-_Defined in [index.ts:346](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L346)_
+_Defined in [index.ts:322](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L322)_
 
 Returns the latest full block in the canonical chain.
 
@@ -292,7 +270,7 @@ Returns the latest full block in the canonical chain.
 
 ▸ **getLatestHeader**(cb: _`any`_): `void`
 
-_Defined in [index.ts:329](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L329)_
+_Defined in [index.ts:305](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L305)_
 
 Returns the latest header in the canonical chain.
 
@@ -312,7 +290,7 @@ Returns the latest header in the canonical chain.
 
 ▸ **iterator**(name: _`string`_, onBlock: _`any`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:992](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L992)_
+_Defined in [index.ts:968](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L968)_
 
 Iterates through blocks starting at the specified iterator head and calls the onBlock function on each block. The current location of an iterator head can be retrieved using the `getHead()` method.
 
@@ -334,7 +312,7 @@ Iterates through blocks starting at the specified iterator head and calls the on
 
 ▸ **putBlock**(block: _`object`_, cb: _`any`_, isGenesis?: _`undefined` \| `false` \| `true`_): `void`
 
-_Defined in [index.ts:375](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L375)_
+_Defined in [index.ts:351](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L351)_
 
 Adds a block to the blockchain.
 
@@ -356,7 +334,7 @@ Adds a block to the blockchain.
 
 ▸ **putBlocks**(blocks: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:359](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L359)_
+_Defined in [index.ts:335](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L335)_
 
 Adds many blocks to the blockchain.
 
@@ -377,7 +355,7 @@ Adds many blocks to the blockchain.
 
 ▸ **putGenesis**(genesis: _`any`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:296](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L296)_
+_Defined in [index.ts:272](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L272)_
 
 Puts the genesis block in the database
 
@@ -398,7 +376,7 @@ Puts the genesis block in the database
 
 ▸ **putHeader**(header: _`object`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:407](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L407)_
+_Defined in [index.ts:383](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L383)_
 
 Adds a header to the blockchain.
 
@@ -419,7 +397,7 @@ Adds a header to the blockchain.
 
 ▸ **putHeaders**(headers: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:391](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L391)_
+_Defined in [index.ts:367](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L367)_
 
 Adds many headers to the blockchain.
 
@@ -440,7 +418,7 @@ Adds many headers to the blockchain.
 
 ▸ **selectNeededHashes**(hashes: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:669](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L669)_
+_Defined in [index.ts:645](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L645)_
 
 Given an ordered array, returns to the callback an array of hashes that are not in the blockchain yet.
 

--- a/docs/classes/blockchain.md
+++ b/docs/classes/blockchain.md
@@ -74,29 +74,21 @@ new Blockchain({ db: db }).iterator(
 
 ### constructor
 
-⊕ **new Blockchain**(opts?: _`any`_): [Blockchain](blockchain.md)
+⊕ **new Blockchain**(opts?: _[BlockchainOptions](../interfaces/blockchainoptions.md)_): [Blockchain](blockchain.md)
 
-_Defined in [index.ts:112](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L112)_
+_Defined in [index.ts:155](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L155)_
 
 Creates new Blockchain object
 
-This constructor receives an object with different options, all of them are optional:
-
-- `opts.chain` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))** The chain for the block \[default: 'mainnet'\]
-- `opts.hardfork` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Hardfork for the block \[default: null, block number-based behavior\]
-- `opts.common` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Alternatively pass a Common instance (ethereumjs-common) instead of setting chain/hardfork directly
-- `opts.db` - Database to store blocks and metadata. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
-- `opts.validate` - this the flag to validate blocks (e.g. Proof-of-Work), latest HF rules supported: `Constantinople`.
-
 **Deprecation note**:
 
-The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDB` from before the Geth DB-compatible `v3.0.0` release are deprecated and continued usage is discouraged. When provided `opts.blockDB` will be used as `opts.db` and `opts.detailsDB` is ignored. On the storage level the DB formats are not compatible and it is not possible to load an old-format DB state into a post-`v3.0.0` `Blockchain` object.
+The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDb` from before the Geth DB-compatible `v3.0.0` release are deprecated and continued usage is discouraged. When provided `opts.blockDB` will be used as `opts.db` and `opts.detailsDB` is ignored. On the storage level the DB formats are not compatible and it is not possible to load an old-format DB state into a post-`v3.0.0` `Blockchain` object.
 
 **Parameters:**
 
-| Name                 | Type  | Default value | Description              |
-| -------------------- | ----- | ------------- | ------------------------ |
-| `Default value` opts | `any` | {}            | See above documentation. |
+| Name                 | Type                                                    | Default value | Description                                                                                                          |
+| -------------------- | ------------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `Default value` opts | [BlockchainOptions](../interfaces/blockchainoptions.md) | {}            | An object with the options that this constructor takes. See [BlockchainOptions](../interfaces/blockchainoptions.md). |
 
 **Returns:** [Blockchain](blockchain.md)
 
@@ -110,7 +102,7 @@ The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDB` 
 
 **● db**: _`any`_
 
-_Defined in [index.ts:105](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L105)_
+_Defined in [index.ts:148](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L148)_
 
 ---
 
@@ -120,7 +112,7 @@ _Defined in [index.ts:105](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● dbManager**: _`DBManager`_
 
-_Defined in [index.ts:106](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L106)_
+_Defined in [index.ts:149](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L149)_
 
 ---
 
@@ -130,7 +122,7 @@ _Defined in [index.ts:106](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● ethash**: _`any`_
 
-_Defined in [index.ts:107](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L107)_
+_Defined in [index.ts:150](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L150)_
 
 ---
 
@@ -140,7 +132,7 @@ _Defined in [index.ts:107](https://github.com/ethereumjs/ethereumjs-blockchain/b
 
 **● validate**: _`boolean`_
 
-_Defined in [index.ts:112](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L112)_
+_Defined in [index.ts:155](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L155)_
 
 A flag indicating if this Blockchain validates blocks or not.
 
@@ -154,7 +146,7 @@ A flag indicating if this Blockchain validates blocks or not.
 
 **get meta**(): `object`
 
-_Defined in [index.ts:175](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L175)_
+_Defined in [index.ts:210](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L210)_
 
 Returns an object with metadata about the Blockchain. It's defined for backwards compatibility.
 
@@ -170,7 +162,7 @@ Returns an object with metadata about the Blockchain. It's defined for backwards
 
 ▸ **delBlock**(blockHash: _`Buffer`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:823](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L823)_
+_Defined in [index.ts:858](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L858)_
 
 Deletes a block from the blockchain. All child blocks in the chain are deleted and any encountered heads are set to the parent block.
 
@@ -191,7 +183,7 @@ Deletes a block from the blockchain. All child blocks in the chain are deleted a
 
 ▸ **getBlock**(blockTag: _`Buffer` \| `number` \| `BN`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:560](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L560)_
+_Defined in [index.ts:595](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L595)_
 
 Gets a block by its hash.
 
@@ -212,7 +204,7 @@ Gets a block by its hash.
 
 ▸ **getBlocks**(blockId: _`Buffer` \| `number`_, maxBlocks: _`number`_, skip: _`number`_, reverse: _`boolean`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:583](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L583)_
+_Defined in [index.ts:618](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L618)_
 
 Looks up many blocks relative to blockId
 
@@ -236,7 +228,7 @@ Looks up many blocks relative to blockId
 
 ▸ **getDetails**(\_: _`string`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:624](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L624)_
+_Defined in [index.ts:659](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L659)_
 
 This method used to return block details by its hash. It's only here for backwards compatibility.
 
@@ -259,7 +251,7 @@ _**deprecated**_:
 
 ▸ **getHead**(name: _`any`_, cb?: _`any`_): `void`
 
-_Defined in [index.ts:271](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L271)_
+_Defined in [index.ts:306](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L306)_
 
 Returns the specified iterator head.
 
@@ -280,7 +272,7 @@ Returns the specified iterator head.
 
 ▸ **getLatestBlock**(cb: _`any`_): `void`
 
-_Defined in [index.ts:311](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L311)_
+_Defined in [index.ts:346](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L346)_
 
 Returns the latest full block in the canonical chain.
 
@@ -300,7 +292,7 @@ Returns the latest full block in the canonical chain.
 
 ▸ **getLatestHeader**(cb: _`any`_): `void`
 
-_Defined in [index.ts:294](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L294)_
+_Defined in [index.ts:329](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L329)_
 
 Returns the latest header in the canonical chain.
 
@@ -320,7 +312,7 @@ Returns the latest header in the canonical chain.
 
 ▸ **iterator**(name: _`string`_, onBlock: _`any`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:957](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L957)_
+_Defined in [index.ts:992](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L992)_
 
 Iterates through blocks starting at the specified iterator head and calls the onBlock function on each block. The current location of an iterator head can be retrieved using the `getHead()` method.
 
@@ -342,7 +334,7 @@ Iterates through blocks starting at the specified iterator head and calls the on
 
 ▸ **putBlock**(block: _`object`_, cb: _`any`_, isGenesis?: _`undefined` \| `false` \| `true`_): `void`
 
-_Defined in [index.ts:340](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L340)_
+_Defined in [index.ts:375](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L375)_
 
 Adds a block to the blockchain.
 
@@ -364,7 +356,7 @@ Adds a block to the blockchain.
 
 ▸ **putBlocks**(blocks: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:324](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L324)_
+_Defined in [index.ts:359](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L359)_
 
 Adds many blocks to the blockchain.
 
@@ -385,7 +377,7 @@ Adds many blocks to the blockchain.
 
 ▸ **putGenesis**(genesis: _`any`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:261](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L261)_
+_Defined in [index.ts:296](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L296)_
 
 Puts the genesis block in the database
 
@@ -406,7 +398,7 @@ Puts the genesis block in the database
 
 ▸ **putHeader**(header: _`object`_, cb: _`any`_): `void`
 
-_Defined in [index.ts:372](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L372)_
+_Defined in [index.ts:407](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L407)_
 
 Adds a header to the blockchain.
 
@@ -427,7 +419,7 @@ Adds a header to the blockchain.
 
 ▸ **putHeaders**(headers: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:356](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L356)_
+_Defined in [index.ts:391](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L391)_
 
 Adds many headers to the blockchain.
 
@@ -448,7 +440,7 @@ Adds many headers to the blockchain.
 
 ▸ **selectNeededHashes**(hashes: _`Array`<`any`>_, cb: _`any`_): `void`
 
-_Defined in [index.ts:634](https://github.com/ethereumjs/ethereumjs-blockchain/blob/c93b4dd/src/index.ts#L634)_
+_Defined in [index.ts:669](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L669)_
 
 Given an ordered array, returns to the callback an array of hashes that are not in the blockchain yet.
 

--- a/docs/interfaces/blockchainoptions.md
+++ b/docs/interfaces/blockchainoptions.md
@@ -1,0 +1,109 @@
+[ethereumjs-blockchain](../README.md) > [BlockchainOptions](../interfaces/blockchainoptions.md)
+
+# Interface: BlockchainOptions
+
+This are the options that the Blockchain constructor can receive.
+
+## Hierarchy
+
+**BlockchainOptions**
+
+## Index
+
+### Properties
+
+- [blockDb](blockchainoptions.md#blockdb)
+- [chain](blockchainoptions.md#chain)
+- [common](blockchainoptions.md#common)
+- [db](blockchainoptions.md#db)
+- [detailsDb](blockchainoptions.md#detailsdb)
+- [hardfork](blockchainoptions.md#hardfork)
+- [validate](blockchainoptions.md#validate)
+
+---
+
+## Properties
+
+<a id="blockdb"></a>
+
+### `<Optional>` blockDb
+
+**● blockDb**: _`any`_
+
+_Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L58)_
+
+_**deprecated**_:
+
+---
+
+<a id="chain"></a>
+
+### `<Optional>` chain
+
+**● chain**: _`string` \| `number`_
+
+_Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L30)_
+
+The chain id or name. Default: `"mainnet"`.
+
+---
+
+<a id="common"></a>
+
+### `<Optional>` common
+
+**● common**: _`Common`_
+
+_Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L41)_
+
+An alternative way to specify the chain and hardfork is by passing a Common instance.
+
+---
+
+<a id="db"></a>
+
+### `<Optional>` db
+
+**● db**: _`any`_
+
+_Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L47)_
+
+Database to store blocks and metadata. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
+
+---
+
+<a id="detailsdb"></a>
+
+### `<Optional>` detailsDb
+
+**● detailsDb**: _`any`_
+
+_Defined in [index.ts:63](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L63)_
+
+_**deprecated**_:
+
+---
+
+<a id="hardfork"></a>
+
+### `<Optional>` hardfork
+
+**● hardfork**: _`string` \| `null`_
+
+_Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L36)_
+
+Hardfork for the blocks. If `undefined` or `null` is passed, it gets computed based on block numbers.
+
+---
+
+<a id="validate"></a>
+
+### `<Optional>` validate
+
+**● validate**: _`undefined` \| `false` \| `true`_
+
+_Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L53)_
+
+This the flag indicates if blocks should be validated (e.g. Proof-of-Work), latest HF rules supported: `Petersburg`.
+
+---

--- a/docs/interfaces/blockchainoptions.md
+++ b/docs/interfaces/blockchainoptions.md
@@ -30,7 +30,7 @@ This are the options that the Blockchain constructor can receive.
 
 **● blockDb**: _`any`_
 
-_Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L58)_
+_Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L58)_
 
 _**deprecated**_:
 
@@ -42,7 +42,7 @@ _**deprecated**_:
 
 **● chain**: _`string` \| `number`_
 
-_Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L30)_
+_Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L30)_
 
 The chain id or name. Default: `"mainnet"`.
 
@@ -54,7 +54,7 @@ The chain id or name. Default: `"mainnet"`.
 
 **● common**: _`Common`_
 
-_Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L41)_
+_Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L41)_
 
 An alternative way to specify the chain and hardfork is by passing a Common instance.
 
@@ -66,7 +66,7 @@ An alternative way to specify the chain and hardfork is by passing a Common inst
 
 **● db**: _`any`_
 
-_Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L47)_
+_Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L47)_
 
 Database to store blocks and metadata. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
 
@@ -78,7 +78,7 @@ Database to store blocks and metadata. Should be a [levelup](https://github.com/
 
 **● detailsDb**: _`any`_
 
-_Defined in [index.ts:63](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L63)_
+_Defined in [index.ts:63](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L63)_
 
 _**deprecated**_:
 
@@ -90,7 +90,7 @@ _**deprecated**_:
 
 **● hardfork**: _`string` \| `null`_
 
-_Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L36)_
+_Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L36)_
 
 Hardfork for the blocks. If `undefined` or `null` is passed, it gets computed based on block numbers.
 
@@ -102,7 +102,7 @@ Hardfork for the blocks. If `undefined` or `null` is passed, it gets computed ba
 
 **● validate**: _`undefined` \| `false` \| `true`_
 
-_Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/ca7662a/src/index.ts#L53)_
+_Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L53)_
 
 This the flag indicates if blocks should be validated (e.g. Proof-of-Work), latest HF rules supported: `Petersburg`.
 

--- a/docs/interfaces/blockchainoptions.md
+++ b/docs/interfaces/blockchainoptions.md
@@ -30,7 +30,7 @@ This are the options that the Blockchain constructor can receive.
 
 **● blockDb**: _`any`_
 
-_Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L58)_
+_Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L58)_
 
 _**deprecated**_:
 
@@ -42,7 +42,7 @@ _**deprecated**_:
 
 **● chain**: _`string` \| `number`_
 
-_Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L30)_
+_Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L30)_
 
 The chain id or name. Default: `"mainnet"`.
 
@@ -54,7 +54,7 @@ The chain id or name. Default: `"mainnet"`.
 
 **● common**: _`Common`_
 
-_Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L41)_
+_Defined in [index.ts:41](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L41)_
 
 An alternative way to specify the chain and hardfork is by passing a Common instance.
 
@@ -66,7 +66,7 @@ An alternative way to specify the chain and hardfork is by passing a Common inst
 
 **● db**: _`any`_
 
-_Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L47)_
+_Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L47)_
 
 Database to store blocks and metadata. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
 
@@ -78,7 +78,7 @@ Database to store blocks and metadata. Should be a [levelup](https://github.com/
 
 **● detailsDb**: _`any`_
 
-_Defined in [index.ts:63](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L63)_
+_Defined in [index.ts:63](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L63)_
 
 _**deprecated**_:
 
@@ -90,7 +90,7 @@ _**deprecated**_:
 
 **● hardfork**: _`string` \| `null`_
 
-_Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L36)_
+_Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L36)_
 
 Hardfork for the blocks. If `undefined` or `null` is passed, it gets computed based on block numbers.
 
@@ -102,7 +102,7 @@ Hardfork for the blocks. If `undefined` or `null` is passed, it gets computed ba
 
 **● validate**: _`undefined` \| `false` \| `true`_
 
-_Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/f54802f/src/index.ts#L53)_
+_Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-blockchain/blob/29a8a30/src/index.ts#L53)_
 
 This the flag indicates if blocks should be validated (e.g. Proof-of-Work), latest HF rules supported: `Petersburg`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,10 +65,6 @@ export interface BlockchainOptions {
 
 /**
  * This class stores and interacts with blocks.
- *
- * @remarks
- * This class performs write operations. Making a backup of your data before trying this module is
- * recommended. Otherwise, you can end up with a compromised DB state.
  */
 export default class Blockchain {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,49 @@ const level = require('level-mem')
 const semaphore = require('semaphore')
 
 /**
+ * This are the options that the Blockchain constructor can receive.
+ */
+export interface BlockchainOptions {
+  /**
+   * The chain id or name. Default: `"mainnet"`.
+   */
+  chain?: string | number
+
+  /**
+   * Hardfork for the blocks. If `undefined` or `null` is passed, it gets computed based on block
+   * numbers.
+   */
+  hardfork?: string | null
+
+  /**
+   * An alternative way to specify the chain and hardfork is by passing a Common instance.
+   */
+  common?: Common
+
+  /**
+   * Database to store blocks and metadata. Should be a
+   * [levelup](https://github.com/rvagg/node-levelup) instance.
+   */
+  db?: any
+
+  /**
+   * This the flag indicates if blocks should be validated (e.g. Proof-of-Work), latest HF rules
+   * supported: `Petersburg`.
+   */
+  validate?: boolean
+
+  /**
+   * @deprecated
+   */
+  blockDb?: any
+
+  /**
+   * @deprecated
+   */
+  detailsDb?: any
+}
+
+/**
  * This class stores and interacts with blocks.
  *
  * @remarks
@@ -114,24 +157,16 @@ export default class Blockchain {
   /**
    * Creates new Blockchain object
    *
-   * This constructor receives an object with different options, all of them are optional:
-   *
-   * * `opts.chain` **([String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number))** The chain for the block [default: 'mainnet']
-   * * `opts.hardfork` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Hardfork for the block [default: null, block number-based behavior]
-   * * `opts.common` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Alternatively pass a Common instance (ethereumjs-common) instead of setting chain/hardfork directly
-   * * `opts.db` - Database to store blocks and metadata. Should be a [levelup](https://github.com/rvagg/node-levelup) instance.
-   * * `opts.validate` - this the flag to validate blocks (e.g. Proof-of-Work), latest HF rules supported: `Constantinople`.
-   *
    * **Deprecation note**:
    *
-   * The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDB` from before the Geth DB-compatible
+   * The old separated DB constructor parameters `opts.blockDB` and `opts.detailsDb` from before the Geth DB-compatible
    * `v3.0.0` release are deprecated and continued usage is discouraged. When provided `opts.blockDB` will be used as
    * `opts.db` and `opts.detailsDB` is ignored. On the storage level the DB formats are not compatible and it is not
    * possible to load an old-format DB state into a post-`v3.0.0` `Blockchain` object.
    *
-   * @param opts See above documentation.
+   * @param opts - An object with the options that this constructor takes. See [[BlockchainOptions]].
    */
-  constructor(opts: any = {}) {
+  constructor(opts: BlockchainOptions = {}) {
     if (opts.common) {
       if (opts.chain) {
         throw new Error('Instantiation with both opts.common and opts.chain parameter not allowed!')

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,30 +69,6 @@ export interface BlockchainOptions {
  * @remarks
  * This class performs write operations. Making a backup of your data before trying this module is
  * recommended. Otherwise, you can end up with a compromised DB state.
- *
- * @example
- * The following is an example to iterate through an existing Geth DB (needs `level` to be
- * installed separately).
- *
- * ```javascript
- * const level = require('level')
- * const Blockchain = require('ethereumjs-blockchain')
- * const utils = require('ethereumjs-util')
- *
- * const gethDbPath = './chaindata' // Add your own path here. It will get modified, see remarks.
- * const db = level(gethDbPath)
- *
- * new Blockchain({ db: db }).iterator(
- *   'i',
- *   (block, reorg, cb) => {
- *     const blockNumber = utils.bufferToInt(block.header.number)
- *     const blockHash = block.hash().toString('hex')
- *     console.log(`BLOCK ${blockNumber}: ${blockHash}`)
- *     cb()
- *   },
- *   err => console.log(err || 'Done.'),
- * )
- * ```
  */
 export default class Blockchain {
   /**


### PR DESCRIPTION
This PR closes #101, #103 and #104.

#101: I couldn't figure out a way of describing the type of a parameter using tsdocs' tags. Instead, I created a `BlockchainOptions` type and documented it.

#103: Super straightforward.

#104: I checked that declared version of ethereumjs-common supports Petersburg. As it does, this change was super simple.