### PR TITLE
Org links and git hooks

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Great that you want to contribute to the `EthereumJS` [ecosystem](https://ethereumjs.readthedocs.io/en/latest/introduction.html). `EthereumJS` is managed by the Ethereum Foundation and largely driven by the wider community. Everyone is welcome to join the effort and help to improve on the libraries (see our [Code of Conduct](https://ethereumjs.readthedocs.io/en/latest/code_of_conduct.html) 🌷).
+
+We have written up some [Contribution Guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html#how-to-start) to help you getting started.
+
+These include information on how we work with **Git** and how our **general workflow** and **technical setup** looks like (stuff like language, tooling, code quality and style).
+
+Happy Coding! 👾 😀 💻

--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ new Blockchain({ db: db }).iterator(
 **WARNING**: Since `ethereumjs-blockchain` is also doing write operations
 on the DB for safety reasons only run this on a copy of your database, otherwise this might lead
 to a compromised DB state.
+
+# EthereumJS
+
+See our organizational [documentation](https://ethereumjs.readthedocs.io) for an introduction to `EthereumJS` as well as information on current standards and best practices.
+
+If you want to join for work or do improvements on the libraries have a look at our [contribution guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "lint:fix": "ethereumjs-config-lint-fix",
     "test": "ts-node node_modules/tape/bin/tape ./test/index.ts"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ethereumjs/ethereumjs-blockchain.git"
@@ -61,6 +66,7 @@
     "@types/semaphore": "^1.1.0",
     "@types/tape": "^4.2.33",
     "coveralls": "^3.0.2",
+    "husky": "^2.1.0",
     "nyc": "^13.0.1",
     "prettier": "^1.16.4",
     "tape": "^4.9.1",


### PR DESCRIPTION
Organization wide application of GitHooks https://github.com/ethereumjs/ethereumjs-account/pull/46 and organizational docs linking https://github.com/ethereumjs/ethereumjs-account/pull/49.