### PR TITLE
Update ethereumjs-block to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "ethashjs": "~0.0.7",
-    "ethereumjs-block": "~2.2.0",
+    "ethereumjs-block": "~2.2.1",
     "ethereumjs-common": "^1.1.0",
     "ethereumjs-util": "~6.1.0",
     "flow-stoplight": "^1.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1044,7 +1044,11 @@ export default class Blockchain implements BlockchainInterface {
     self._hashToNumber(blockHash, (err?: any, number?: any) => {
       if (err) return cb(err)
       blockNumber = number.addn(1)
-      async.whilst(() => blockNumber, run, err => (err ? cb(err) : self._saveHeads(cb)))
+      async.whilst(
+        () => blockNumber,
+        run,
+        err => (err ? cb(err) : self._saveHeads(cb)),
+      )
     })
 
     function run(cb2: any) {


### PR DESCRIPTION
This version of `ethereumjs-block` comes with the most recent `ethereumjs-tx` which has the Istanbul calldata fee reduction.