### PR TITLE
fix coverage by including dist

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,3 +1,6 @@
 {
-  "extends": "@ethereumjs/config-nyc"
+  "extends": "@ethereumjs/config-nyc",
+  "include": [
+    "dist/**/*.js"
+  ]
 }


### PR DESCRIPTION
I forgot to add the code for `.nycrc` [from Holger's comment](https://github.com/ethereumjs/ethereumjs-blockchain/pull/134#issuecomment-560350726) to include calculating coverage from `dist`.

It's included in this PR - thanks Holger!

closes #139 