### PR TITLE
New release v4.0.3 (MuirGlacier), block and common updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.3] - 2019-12-19
+
+Supports `MuirGlacier` by updating `ethereumjs-block` to
+[v2.2.2](https://github.com/ethereumjs/ethereumjs-block/releases/tag/v2.2.2)
+and `ethereumjs-common` to
+[v1.5.0](https://github.com/ethereumjs/ethereumjs-common/releases/tag/v1.5.0).
+
+This release comes also with a completely refactored test suite, see
+PR [#134](https://github.com/ethereumjs/ethereumjs-blockchain/pull/134).
+Tests are now less coupled and it gets easier to modify tests or extend
+the test suite.
+
+[4.0.3]: https://github.com/ethereumjs/ethereumjs-blockchain/compare/v4.0.2...v4.0.3
+
 ## [4.0.2] - 2019-11-15
 
 Supports Istanbul by updating `ethereumjs-block` to

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "dependencies": {
     "async": "^2.6.1",
     "ethashjs": "~0.0.7",
-    "ethereumjs-block": "~2.2.1",
-    "ethereumjs-common": "^1.1.0",
+    "ethereumjs-block": "~2.2.2",
+    "ethereumjs-common": "^1.5.0",
     "ethereumjs-util": "~6.1.0",
     "flow-stoplight": "^1.0.0",
     "level-mem": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockchain",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "A module to store and interact with blocks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/index.ts
+++ b/test/index.ts
@@ -871,11 +871,11 @@ test('blockchain test', t => {
   })
 
   t.test('mismatched chains', st => {
-    const common = new Common('rinkeby')
+    const common = new Common('mainnet')
     const blockchain = new Blockchain({ common: common, validateBlocks: true, validatePow: false })
     const blocks = [
       new Block(null, { common: common }),
-      new Block(null, { chain: 'rinkeby' }),
+      new Block(null, { chain: 'mainnet' }),
       new Block(null, { chain: 'ropsten' }),
     ]
 


### PR DESCRIPTION
This PR updates the block and common dependencies and provides release notes for a `v4.0.3` release. 

The analysis/assignment of the failing tests to a potential bug in the `block` library was actually wrong. This was triggered because a MuirGlacier-containing PoW chain (Ropsten) block was compared to a non MuirGlacier chain (Rinkeby) block in the `block.canonicalDifficulty()` code, leading to the `>= MuirGlacier` comparison falsely evaluating to true for a non-HF initialized block. 

This could be fixed here by a slight update on the mismatched-chains test case by continuing to use different chains (to keep the tested case to be triggered) but switch to two PoW chains both containing the `MuirGlacier` fork.