### PR TITLE
Makes building files unnecessary to run tests

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,6 +1,6 @@
 {
   "extends": "@ethereumjs/config-nyc",
   "include": [
-    "dist/**/*.js"
+    "src/*.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tsc": "ethereumjs-config-tsc",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
-    "test": "npm run build && ts-node node_modules/tape/bin/tape ./test/index.ts"
+    "test": "ts-node node_modules/tape/bin/tape ./test/index.ts"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tsc": "ethereumjs-config-tsc",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
-    "test": "ts-node node_modules/tape/bin/tape ./test/index.ts"
+    "test": "nyc --reporter=lcov ts-node node_modules/tape/bin/tape ./test/index.ts"
   },
   "husky": {
     "hooks": {

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,7 +2,7 @@ import * as async from 'async'
 import Common from 'ethereumjs-common'
 import { toBuffer, bufferToInt } from 'ethereumjs-util'
 import * as test from 'tape'
-import Blockchain, { Block } from '../dist'
+import Blockchain, { Block } from '../src'
 import { generateBlockchain, generateBlocks, isConsecutive, createTestDB } from './util'
 
 import BN = require('bn.js')

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,6 +1,6 @@
 import { rlp, toBuffer, bufferToInt } from 'ethereumjs-util'
 import BN = require('bn.js')
-import Blockchain, { Block } from '../dist'
+import Blockchain, { Block } from '../src'
 
 const util = require('util')
 const Block = require('ethereumjs-block')


### PR DESCRIPTION
Normalizing effort based on [this comment](https://github.com/ethereumjs/ethereumjs-vm/issues/561#issuecomment-577371591).

It uses `ts-node` for testing, requiring from `src` instead of `dist`.